### PR TITLE
Feature/44 configurable session timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+### Added
+* cas config etcd key `session_tgt/max_time_to_live_in_seconds` to configure maximum session timeout
+* cas config etcd key `session_tgt/time_to_kill_in_seconds` to configure idle session timeout

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@195e15a')
+@Library('github.com/cloudogu/ces-build-lib@a5799c2')
 import com.cloudogu.ces.cesbuildlib.*
 
 node() { // No specific label

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@a5799c2')
+@Library('github.com/cloudogu/ces-build-lib@195e15a')
 import com.cloudogu.ces.cesbuildlib.*
 
 node() { // No specific label

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -170,7 +170,7 @@
             <groupId>com.github.cloudogu</groupId>
             <artifactId>ces-build-lib</artifactId>
             <!-- Keep this version in sync with the one used in Jenkinsfile -->
-            <version>195e15a</version>
+            <version>a5799c2</version>
             <!-- Don't ship this dependency with the app -->
             <optional>true</optional>
         </dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -170,7 +170,7 @@
             <groupId>com.github.cloudogu</groupId>
             <artifactId>ces-build-lib</artifactId>
             <!-- Keep this version in sync with the one used in Jenkinsfile -->
-            <version>888733b</version>
+            <version>195e15a</version>
             <!-- Don't ship this dependency with the app -->
             <optional>true</optional>
         </dependency>

--- a/dogu.json
+++ b/dogu.json
@@ -44,6 +44,15 @@
     "Name": "legal_urls/privacy_policy",
     "Description": "This URL links to the Privacy Policy and will be the last link at the bottom of login or logout pages. If empty the whole link will be omitted. If changed the CAS dogu must be restarted to take effect.",
     "Optional": true
+  },{
+    "Name": "session_tgt/max_time_to_live_in_seconds",
+    "Description": "Maximum session timeout - TGT will expire after defined timespan regardless the usage",
+    "Optional": true
+  },
+  {
+    "Name": "session_tgt/time_to_kill_in_seconds",
+    "Description": "Idle session timeout -  TGT will expire sooner if no further requests keep the session alive",
+    "Optional": true
   }],
   "Volumes": [{
     "Name": "data",

--- a/resources/opt/apache-tomcat/cas.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/cas.properties.conf.tpl
@@ -22,19 +22,12 @@
 #
 # Maximum session timeout - TGT will expire in maxTimeToLiveInSeconds regardless of usage
 
-{{ if .Config.Exists "session_tgt/max_time_to_live_in_seconds" }}
-tgt.maxTimeToLiveInSeconds={{ .Config.Get "session_tgt/max_time_to_live_in_seconds"}}
-{{ else }}
 # default value 24h
-tgt.maxTimeToLiveInSeconds=90000
-{{ end }}
+tgt.maxTimeToLiveInSeconds= {{ .Config.GetOrDefault "session_tgt/max_time_to_live_in_seconds" "86400"}}
 
 # Idle session timeout -  TGT will expire sooner than maxTimeToLiveInSeconds if no further requests
 # for STs occur within timeToKillInSeconds
 
-{{ if .Config.Exists "session_tgt/time_to_kill_in_seconds" }}
-tgt.timeToKillInSeconds={{ .Config.Get "session_tgt/time_to_kill_in_seconds"}}
-{{ else }}
 # default value 10h
-tgt.timeToKillInSeconds=36000
-{{ end }}
+tgt.timeToKillInSeconds={{ .Config.GetOrDefault "session_tgt/time_to_kill_in_seconds" "36000"}}
+

--- a/resources/opt/apache-tomcat/cas.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/cas.properties.conf.tpl
@@ -1,0 +1,40 @@
+#
+# Licensed to Jasig under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Jasig licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Single Sign-On Session Timeouts
+# Defaults sourced from WEB-INF/spring-configuration/ticketExpirationPolices.xml
+#
+# Maximum session timeout - TGT will expire in maxTimeToLiveInSeconds regardless of usage
+
+{{ if .Config.Exists "session_tgt/max_time_to_live_in_seconds" }}
+tgt.maxTimeToLiveInSeconds={{ .Config.Get "session_tgt/max_time_to_live_in_seconds"}}
+{{ else }}
+# default value 24h
+tgt.maxTimeToLiveInSeconds=90000
+{{ end }}
+
+# Idle session timeout -  TGT will expire sooner than maxTimeToLiveInSeconds if no further requests
+# for STs occur within timeToKillInSeconds
+
+{{ if .Config.Exists "session_tgt/time_to_kill_in_seconds" }}
+tgt.timeToKillInSeconds={{ .Config.Get "session_tgt/time_to_kill_in_seconds"}}
+{{ else }}
+# default value 10h
+tgt.timeToKillInSeconds=36000
+{{ end }}

--- a/resources/opt/apache-tomcat/cas.properties.tpl
+++ b/resources/opt/apache-tomcat/cas.properties.tpl
@@ -1,22 +1,3 @@
-#
-# Licensed to Jasig under one or more contributor license
-# agreements. See the NOTICE file distributed with this work
-# for additional information regarding copyright ownership.
-# Jasig licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file
-# except in compliance with the License.  You may obtain a
-# copy of the License at the following location:
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
 ##
 # Services Management Web UI Security
 server.name=https://%FQDN%

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -22,6 +22,10 @@ function global_cfg_or_default {
 }
 
 MESSAGES_PROPERTIES_FILE="/opt/apache-tomcat/webapps/cas/WEB-INF/classes/messages.properties"
+CAS_PROPERTIES_TEMPLATE="/opt/apache-tomcat/cas.properties.conf.tpl"
+CAS_PROPERTIES="/opt/apache-tomcat/webapps/cas/WEB-INF/cas.properties"
+
+doguctl template ${CAS_PROPERTIES_TEMPLATE} ${CAS_PROPERTIES}
 
 echo "Getting general variables for templates..."
 DOMAIN=$(doguctl config --global domain)
@@ -116,7 +120,7 @@ s@%LDAP_USE_USER_CONNECTION%@$LDAP_USE_USER_CONNECTION@g;\
 s@%LOGIN_LIMIT_MAX_NUMBER%@$LOGIN_LIMIT_MAX_NUMBER@g;\
 s@%LOGIN_LIMIT_FAILURE_STORE_TIME%@$LOGIN_LIMIT_FAILURE_STORE_TIME@g;\
 s@%LOGIN_LIMIT_LOCK_TIME%@$LOGIN_LIMIT_LOCK_TIME@g"\
- /opt/apache-tomcat/cas.properties.tpl > /opt/apache-tomcat/webapps/cas/WEB-INF/cas.properties
+ /opt/apache-tomcat/cas.properties.tpl >> /opt/apache-tomcat/webapps/cas/WEB-INF/cas.properties
 
 
 sed -i '/screen.password.forgotText=/d' ${MESSAGES_PROPERTIES_FILE}

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -25,6 +25,7 @@ MESSAGES_PROPERTIES_FILE="/opt/apache-tomcat/webapps/cas/WEB-INF/classes/message
 CAS_PROPERTIES_TEMPLATE="/opt/apache-tomcat/cas.properties.conf.tpl"
 CAS_PROPERTIES="/opt/apache-tomcat/webapps/cas/WEB-INF/cas.properties"
 
+# use the doguctl templating mechanism for new configuration entries (sed is deprecated and should be migrated)
 doguctl template ${CAS_PROPERTIES_TEMPLATE} ${CAS_PROPERTIES}
 
 echo "Getting general variables for templates..."


### PR DESCRIPTION
Implement etcdkeys to configure the following cas.properties values:

- tgt.maxTimeToLiveInSeconds (max session timeout regardless of usage)
- tgt.timeToKillInSeconds (session timeout without usage / no requests)

Due to our etcdkey policy we decided to implement them as

session_tgt/max_time_to_live_in_seconds
session_tgt/time_to_kill_in_seconds

