### PR TITLE
#49 implements configurable logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added 
+
+A new CES registry key `logging/root` is evaluated to override the default root log level (#49). One of these values can be set in order to increase the log verbosity: `ERROR`, `WARN`, `INFO`, `DEBUG`. 
+
+CAS's Log4J log levels are directly applied from the root log level.
+
+Tomcat log levels are mapped from the root log level as follows:
+
+| root log level | Tomcat log level |
+|----------------|------------------|
+| ERROR | Everything equal or above ERROR |
+| WARN  | Everything equal or above WARNING |
+| INFO  | Everything equal or above INFO |
+| DEBUG | Everything equal or above FINE |
+
+### Changed
+
+Under the hood we verify the Tomcat binary to spot (possibly) tampered Tomcat binaries during the build time. (#38)
+
+### Fixed
+
+PerformanceStats are no longer logged to the container filesystem for reasons of discoverability and performance. Instead they are logged to the usual CES logging facility. (#48)
 
 ## [v4.0.7.20-7](https://github.com/cloudogu/cas/releases/tag/v4.0.7.20-7) - 2020-03-12 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ COPY resources /
 # expose tomcat port
 EXPOSE 8080
 
+HEALTHCHECK CMD doguctl healthy cas || exit 1
+
 # start tomcat as user tomcat
 CMD /startup.sh
 
-HEALTHCHECK CMD [ $(doguctl healthy cas; echo $?) == 0 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ RUN set -x \
 
 # registry.cloudogu.com/official/cas
 FROM registry.cloudogu.com/official/java:8u212-1
-LABEL maintainer="michael.behlendorf@cloudogu.com"
+
+LABEL NAME="official/cas" \
+    VERSION="4.0.7.20-7" \
+    maintainer="michael.behlendorf@cloudogu.com"
 
 # configure environment
 ENV TOMCAT_MAJOR_VERSION=8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV TOMCAT_MAJOR_VERSION=8 \
 	CATALINA_BASE=/opt/apache-tomcat \
 	CATALINA_PID=/var/run/tomcat7.pid \
 	CATALINA_SH=/opt/apache-tomcat/bin/catalina.sh \
-	SERVICE_TAGS=webapp
+	SERVICE_TAGS=webapp \
+	TOMCAT_TARGZ_SHA256=19a047c4425c4ea796215d397b7caeda958c764981624ea5c4f763d98d2db7fa
 
 COPY --from=builder /cas/target/cas.war /cas.war
 
@@ -29,10 +30,10 @@ RUN set -x \
  && adduser -S -h /var/lib/cas -s /bin/bash -G cas -u 1000 cas \
  # install tomcat
  && mkdir -p /opt \
- && curl --fail --silent --location --retry 3 \
- 		http://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- | gunzip \
- | tar x -C /opt \
+ && wget --progress=bar:force:noscroll "http://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz" \
+ && echo "${TOMCAT_TARGZ_SHA256} *apache-tomcat-${TOMCAT_VERSION}.tar.gz" | sha256sum -c - \
+ && tar -C /opt -xzvf "apache-tomcat-${TOMCAT_VERSION}.tar.gz" \
+ && rm -f "apache-tomcat-${TOMCAT_VERSION}.tar.gz" \
  && mv /opt/apache-tomcat-* ${CATALINA_BASE} \
  && rm -rf ${CATALINA_BASE}/webapps/* \
  # install cas webapp application

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x \
     && mvn package
 
 # registry.cloudogu.com/official/cas
-FROM registry.cloudogu.com/official/java:8u212-1
+FROM registry.cloudogu.com/official/java:8u242-1
 
 LABEL NAME="official/cas" \
     VERSION="4.0.7.20-7" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,72 +4,73 @@ import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 
 node() { // No specific label
+    timestamps {
+        properties([
+                // Keep only the last 10 build to preserve space
+                buildDiscarder(logRotator(numToKeepStr: '10')),
+                // Don't run concurrent builds for a branch, because they use the same workspace directory
+                disableConcurrentBuilds()
+        ])
 
-    properties([
-            // Keep only the last 10 build to preserve space
-            buildDiscarder(logRotator(numToKeepStr: '10')),
-            // Don't run concurrent builds for a branch, because they use the same workspace directory
-            disableConcurrentBuilds()
-    ])
+        String defaultEmailRecipients = env.EMAIL_RECIPIENTS
 
-    String defaultEmailRecipients = env.EMAIL_RECIPIENTS
+        catchError {
 
-    catchError {
+            def mvnHome = tool 'M3'
+            def javaHome = tool 'JDK8'
 
-        def mvnHome = tool 'M3'
-        def javaHome = tool 'JDK8'
+            Maven mvn = new MavenLocal(this, mvnHome, javaHome)
+            Git git = new Git(this)
 
-        Maven mvn = new MavenLocal(this, mvnHome, javaHome)
-        Git git = new Git(this)
-
-        stage('Checkout') {
-            checkout scm
-            git.clean("")
-        }
-
-        stage('Lint') {
-            lintDockerfile()
-        }
-
-        stage('Shellcheck'){
-            // TODO: Change this to shellCheck("./resources") as soon as https://github.com/cloudogu/dogu-build-lib/issues/8 is solved
-            shellCheck("./resources/startup.sh ./resources/logging.sh")
-        }
-
-        dir('app') {
-            stage('Build') {
-                setupMaven(mvn)
-                mvn 'clean install -DskipTests'
-                archiveArtifacts '**/target/*.jar,**/target/*.zip'
+            stage('Checkout') {
+                checkout scm
+                git.clean("")
             }
 
-            stage('Unit Test') {
-                mvn 'test'
+            stage('Lint') {
+                lintDockerfile()
             }
 
-            stage('SonarQube') {
-                withSonarQubeEnv {
-                    def mvnSonarParameters = "-Dsonar.host.url=${env.SONAR_HOST_URL} " +
-                            "-Dsonar.exclusions=target/**,src/main/webapp/**/* " +
-                            "-Dsonar.projectKey=cas:${env.BRANCH_NAME} -Dsonar.projectName=cas:${env.BRANCH_NAME} " +
-                            "-Dsonar.github.repository=cloudogu/cas " +
-                            "-Dsonar.github.oauth=${env.SONAR_AUTH_TOKEN}"
-                    mvn "${env.SONAR_MAVEN_GOAL} ${mvnSonarParameters}"
+            stage('Shellcheck') {
+                // TODO: Change this to shellCheck("./resources") as soon as https://github.com/cloudogu/dogu-build-lib/issues/8 is solved
+                shellCheck("./resources/startup.sh ./resources/logging.sh")
+            }
+
+            dir('app') {
+                stage('Build') {
+                    setupMaven(mvn)
+                    mvn 'clean install -DskipTests'
+                    archiveArtifacts '**/target/*.jar,**/target/*.zip'
                 }
-                timeout(time: 2, unit: 'MINUTES') { // Needed when there is no webhook for example
-                    def qGate = waitForQualityGate()
-                    if (qGate.status != 'OK') {
-                        unstable("Pipeline unstable due to SonarQube quality gate failure")
+
+                stage('Unit Test') {
+                    mvn 'test'
+                }
+
+                stage('SonarQube') {
+                    withSonarQubeEnv {
+                        def mvnSonarParameters = "-Dsonar.host.url=${env.SONAR_HOST_URL} " +
+                                "-Dsonar.exclusions=target/**,src/main/webapp/**/* " +
+                                "-Dsonar.projectKey=cas:${env.BRANCH_NAME} -Dsonar.projectName=cas:${env.BRANCH_NAME} " +
+                                "-Dsonar.github.repository=cloudogu/cas " +
+                                "-Dsonar.github.oauth=${env.SONAR_AUTH_TOKEN}"
+                        mvn "${env.SONAR_MAVEN_GOAL} ${mvnSonarParameters}"
+                    }
+                    timeout(time: 2, unit: 'MINUTES') { // Needed when there is no webhook for example
+                        def qGate = waitForQualityGate()
+                        if (qGate.status != 'OK') {
+                            unstable("Pipeline unstable due to SonarQube quality gate failure")
+                        }
                     }
                 }
             }
         }
+
+        // Archive Unit and integration test results, if any
+        junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
+
+        mailIfStatusChanged(findEmailRecipients(defaultEmailRecipients))
     }
-
-    // Archive Unit and integration test results, if any
-    junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
-
-    mailIfStatusChanged(findEmailRecipients(defaultEmailRecipients))
 }
 
 def setupMaven(mvn) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@a5799c2')
+@Library(['github.com/cloudogu/ces-build-lib@a5799c2', 'github.com/cloudogu/dogu-build-lib@414bdfd5']) _
 import com.cloudogu.ces.cesbuildlib.*
+import com.cloudogu.ces.dogubuildlib.*
 
 node() { // No specific label
 
@@ -24,6 +25,15 @@ node() { // No specific label
         stage('Checkout') {
             checkout scm
             git.clean("")
+        }
+
+        stage('Lint') {
+            lintDockerfile()
+        }
+
+        stage('Shellcheck'){
+            // TODO: Change this to shellCheck("./resources") as soon as https://github.com/cloudogu/dogu-build-lib/issues/8 is solved
+            shellCheck("./resources/startup.sh ./resources/logging.sh")
         }
 
         dir('app') {

--- a/app/src/main/resources/log4j.xml
+++ b/app/src/main/resources/log4j.xml
@@ -49,17 +49,9 @@
     -->
     <appender name="CoalescingStatistics" class="org.perf4j.log4j.AsyncCoalescingStatisticsAppender">
         <param name="TimeSlice" value="60000"/>
-        <appender-ref ref="fileAppender"/>
+        <appender-ref ref="console"/>
         <appender-ref ref="graphExecutionTimes"/>
         <appender-ref ref="graphExecutionTPS"/>
-    </appender>
-
-    <!-- This file appender is used to output aggregated performance statistics -->
-    <appender name="fileAppender" class="org.apache.log4j.FileAppender">
-        <param name="File" value="logs/perfStats.log"/>
-        <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%m%n"/>
-        </layout>
     </appender>
 
     <appender name="graphExecutionTimes" class="org.perf4j.log4j.GraphingStatisticsAppender">

--- a/app/src/main/resources/log4j.xml
+++ b/app/src/main/resources/log4j.xml
@@ -83,7 +83,7 @@
       upstream loggers.
     -->
     <logger name="org.perf4j.TimingLogger" additivity="false">
-        <level value="INFO" />
+        <level value="WARN" />
         <appender-ref ref="CoalescingStatistics" />
     </logger>
 
@@ -102,17 +102,17 @@
     </logger>
 
     <logger name="de.triology" additivity="true">
-        <level value="TRACE" />
+        <level value="WARN" />
         <appender-ref ref="cas" />
     </logger>
 
     <logger name="org.jasig" additivity="true">
-        <level value="INFO" />
+        <level value="WARN" />
         <appender-ref ref="cas" />
     </logger>
 
     <logger name="com.github.inspektr.audit.support.Slf4jLoggingAuditTrailManager">
-        <level value="INFO" />
+        <level value="WARN" />
         <appender-ref ref="cas" />
     </logger>
 
@@ -131,7 +131,7 @@
         cleartext authentication credentials
     -->
     <logger name="org.jasig.cas.web.flow" additivity="true">
-        <level value="INFO" />
+        <level value="WARN" />
         <appender-ref ref="cas" />
     </logger>
 

--- a/dogu.json
+++ b/dogu.json
@@ -53,6 +53,11 @@
     "Name": "session_tgt/time_to_kill_in_seconds",
     "Description": "Idle session timeout -  TGT will expire sooner if no further requests keep the session alive",
     "Optional": true
+  },
+  {
+    "Name": "logging/root",
+    "Description": "Configure the logging behaviour - Supported log levels are [ERROR, WARN, INFO, DEBUG] the default value is WARN",
+    "Optional": true
   }],
   "Volumes": [{
     "Name": "data",

--- a/dogu.json
+++ b/dogu.json
@@ -70,8 +70,13 @@
     "Type": "ldap",
     "Params": ["ro"]
   }],
-  "HealthCheck": {
-    "Type": "tcp",
-    "Port": 8080
-  }
+  "HealthChecks": [
+    {
+      "Type": "tcp",
+      "Port": 8080
+    },
+    {
+      "Type": "state"
+    }
+  ]
 }

--- a/resources/etc/cas/conf/log4j.xml.tpl
+++ b/resources/etc/cas/conf/log4j.xml.tpl
@@ -28,7 +28,7 @@
     -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d %p [%c] - &lt;%m&gt;%n"/>
+            <param name="ConversionPattern" value="%d{dd-MMM-yyyy HH:mm:ss.SSS} %p [%c] - %m%n"/>
         </layout>
     </appender>
 
@@ -37,7 +37,7 @@
         <param name="MaxFileSize" value="512KB" />
         <param name="MaxBackupIndex" value="3" />
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d %p [%c] - %m%n"/>
+            <param name="ConversionPattern" value="%d{dd-MMM-yyyy HH:mm:ss.SSS} %p [%c] - %m%n"/>
         </layout>
     </appender>
 
@@ -75,7 +75,7 @@
       upstream loggers.
     -->
     <logger name="org.perf4j.TimingLogger" additivity="false">
-        <level value="WARN" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
         <appender-ref ref="CoalescingStatistics" />
     </logger>
 
@@ -86,26 +86,28 @@
         apply DEBUG level logging on a an org.springframework.* package level (i.e. org.springframework.dao)
     -->
     <logger name="org.springframework">
-        <level value="WARN" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <logger name="org.springframework.webflow">
-        <level value="WARN" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <logger name="de.triology" additivity="true">
-        <level value="WARN" />
-        <appender-ref ref="cas" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <logger name="org.jasig" additivity="true">
-        <level value="WARN" />
-        <appender-ref ref="cas" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <logger name="com.github.inspektr.audit.support.Slf4jLoggingAuditTrailManager">
-        <level value="WARN" />
-        <appender-ref ref="cas" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <!--
@@ -113,8 +115,8 @@
         The code [xxx] cannot be found in the language bundle for the locale [en_US]
     -->
     <logger name="org.jasig.cas.web.view.CasReloadableMessageBundle">
-        <level value="ERROR" />
-        <appender-ref ref="cas" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <!--
@@ -123,8 +125,8 @@
         cleartext authentication credentials
     -->
     <logger name="org.jasig.cas.web.flow" additivity="true">
-        <level value="WARN" />
-        <appender-ref ref="cas" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <appender-ref ref="console" />
     </logger>
 
     <!--
@@ -132,7 +134,9 @@
       logger to System.out.
     -->
     <root>
-        <level value="ERROR" />
+        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
         <appender-ref ref="console" />
     </root>
 </log4j:configuration>
+
+

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -84,7 +84,7 @@ function validateDoguLogLevel() {
   fi
 
   # Things really got weird: Falling back to default
-  echo "${SCRIPT_LOG_PREFIX} Found unsupported log level ${logLevel}. These log levels are supported: ${VALID_LOG_LEVELS[@]}"
+  echo "${SCRIPT_LOG_PREFIX} Found unsupported log level ${logLevel}. These log levels are supported: ${VALID_LOG_LEVELS[*]}"
   resetDoguLogLevel "${logLevel}" "${DEFAULT_LOG_LEVEL}"
   return
 }
@@ -92,12 +92,13 @@ function validateDoguLogLevel() {
 function containsValidLogLevel() {
   foundLogLevel="${1}"
 
-  # The added spaces in this test avoid partial matches. F. ex., the invalid value "ERR" could falsely match "ERROR"
-  if [[ " ${VALID_LOG_LEVELS[@]} " =~ " ${foundLogLevel} " ]]; then
-    return 0
-  else
-    return 1
-  fi
+  for value in "${VALID_LOG_VALUES[@]}"; do
+    if [[ "${value}" == "${foundLogLevel}" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 function resetDoguLogLevel() {

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -16,6 +16,8 @@ TOMCAT_LOGGING_TEMPLATE="/opt/apache-tomcat/conf/logging.properties.conf.tpl"
 TOMCAT_LOGGING="/opt/apache-tomcat/conf/logging.properties"
 SCRIPT_LOG_PREFIX="Log level mapping:"
 
+CAS_LOGGING_TEMPLATE="/etc/cas/conf/log4j.xml.tpl"
+CAS_LOGGING="/opt/apache-tomcat/webapps/cas/WEB-INF/classes/log4j.xml"
 # create a mapping because apache uses different log levels than log4j eg. ERROR=>SEVERE
 function mapDoguLogLevel() {
   echo "${SCRIPT_LOG_PREFIX} Mapping dogu specific log level"
@@ -111,4 +113,5 @@ mapDoguLogLevel
 echo "Log level mapping ended successfully..."
 
 echo "Rendering logging configuration..."
+doguctl template ${CAS_LOGGING_TEMPLATE} ${CAS_LOGGING}
 doguctl template ${TOMCAT_LOGGING_TEMPLATE} ${TOMCAT_LOGGING}

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -67,7 +67,7 @@ function validateDoguLogLevel() {
   if [[ "${logLevel}" == "" ]]; then
     echo "${SCRIPT_LOG_PREFIX} Found empty root log level. Setting log level default to ${DEFAULT_LOG_LEVEL}"
     # note the quotations to force bash to use it as the first argument.
-    resetDoguLogLevel "${logLevel}" ${DEFAULT_LOG_LEVEL}
+    resetDoguLogLevel "${logLevel}" "${DEFAULT_LOG_LEVEL}"
     return
   fi
 
@@ -83,7 +83,7 @@ function validateDoguLogLevel() {
 
   # Things really got weird: Falling back to default
   echo "${SCRIPT_LOG_PREFIX} Found unsupported log level ${logLevel}. These log levels are supported: ${VALID_LOG_LEVELS[@]}"
-  resetDoguLogLevel ${logLevel} ${DEFAULT_LOG_LEVEL}
+  resetDoguLogLevel "${logLevel}" "${DEFAULT_LOG_LEVEL}"
   return
 }
 

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -20,9 +20,7 @@ SCRIPT_LOG_PREFIX="Log level mapping:"
 function mapDoguLogLevel() {
   echo "${SCRIPT_LOG_PREFIX} Mapping dogu specific log level"
   currentLogLevel=$(doguctl config --default "${DEFAULT_LOG_LEVEL}" "${DEFAULT_LOGGING_KEY}")
-  if [[ "$?" != "0" ]] ; then
-    currentLogLevel="not found"
-  fi
+
   echo "${SCRIPT_LOG_PREFIX} Mapping ${currentLogLevel} to Catalina"
   case "${currentLogLevel}" in
     "${LOG_LEVEL_ERROR}")

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# logging behaviour can be configured in /cas/logging/root with the following options <ERROR,WARN,INFO,DEBUG>
+DEFAULT_LOGGING_KEY="logging/root"
+LOG_LEVEL_ERROR="ERROR"; LOG_LEVEL_WARN="WARN"; LOG_LEVEL_INFO="INFO"; LOG_LEVEL_DEBUG="DEBUG"
+
+# list of accepted log levels
+VALID_LOG_LEVELS=( "${LOG_LEVEL_ERROR}" "${LOG_LEVEL_WARN}" "${LOG_LEVEL_INFO}" "${LOG_LEVEL_DEBUG}" )
+DEFAULT_LOG_LEVEL=${LOG_LEVEL_WARN}
+
+# logging configuration used to configure the apache-tomcat logging mechanism
+TOMCAT_LOGGING_TEMPLATE="/opt/apache-tomcat/conf/logging.properties.conf.tpl"
+TOMCAT_LOGGING="/opt/apache-tomcat/conf/logging.properties"
+
+# create a mapping because apache uses different log levels than log4j eg. ERROR=>SEVERE
+function mapDoguLogLevel() {
+  currentLogLevel=$(doguctl config "${DEFAULT_LOGGING_KEY}")
+  case "${currentLogLevel}" in
+    "${LOG_LEVEL_ERROR}")
+      export CATALINA_LOGLEVEL="SEVERE"
+    ;;
+    "${LOG_LEVEL_INFO}")
+      export CATALINA_LOGLEVEL="INFO"
+    ;;
+    "${LOG_LEVEL_DEBUG}")
+      export CATALINA_LOGLEVEL="FINE"
+    ;;
+    *)
+      export CATALINA_LOGLEVEL="WARNING"
+    ;;
+  esac
+}
+
+# validate key entries and correct them if needed
+function validateDoguLogLevel() {
+  logLevel=$(doguctl config --default "${DEFAULT_LOG_LEVEL}" "${DEFAULT_LOGGING_KEY}")
+  # "config --default" accepts a set key with an empty value
+  if [[ "${logLevel}" == "" ]]; then
+    echo "Did not find missing log level."
+    resetDoguLogLevel ${logLevel} ${DEFAULT_LOG_LEVEL}
+    return
+  fi
+
+  uppercaseLogLevel=${logLevel^^}
+  if [[ "${logLevel}" != "${uppercaseLogLevel}" ]]; then
+    echo "Found lowercase log level. Converting ${logLevel} to ${uppercaseLogLevel}..."
+  fi
+
+  # The added spaces in this test avoid partial matches. F. ex., the invalid value "ERR" could falsely match "ERROR"
+  if [[ " ${VALID_LOG_LEVELS[@]} " =~ " ${uppercaseLogLevel} " ]]; then
+    echo "Using log level ${uppercaseLogLevel}..."
+    return
+  else
+    echo "Found unsupported log level ${uppercaseLogLevel}. These log levels are supported: ${VALID_LOG_LEVELS[@]}"
+    resetDoguLogLevel ${uppercaseLogLevel} ${defaultLogLevel}
+    return
+  fi
+}
+
+function resetDoguLogLevel() {
+  targetLogLevel=${2}
+  echo "Resetting dogu log level from ${1} to ${targetLogLevel}..."
+  doguctl config "${DEFAULT_LOGGING_KEY}" "${targetLogLevel}"
+}
+
+echo "Rendering logging configuration..."
+validateDoguLogLevel
+mapDoguLogLevel
+
+doguctl template ${TOMCAT_LOGGING_TEMPLATE} ${TOMCAT_LOGGING}

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -55,7 +55,7 @@ function validateDoguLogLevel() {
     return
   else
     echo "Found unsupported log level ${uppercaseLogLevel}. These log levels are supported: ${VALID_LOG_LEVELS[@]}"
-    resetDoguLogLevel ${uppercaseLogLevel} ${defaultLogLevel}
+    resetDoguLogLevel ${uppercaseLogLevel} ${DEFAULT_LOG_LEVEL}
     return
   fi
 }

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -92,7 +92,7 @@ function validateDoguLogLevel() {
 function containsValidLogLevel() {
   foundLogLevel="${1}"
 
-  for value in "${VALID_LOG_VALUES[@]}"; do
+  for value in "${VALID_LOG_LEVELS[@]}"; do
     if [[ "${value}" == "${foundLogLevel}" ]]; then
       return 0
     fi

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -18,7 +18,7 @@ SCRIPT_LOG_PREFIX="Log level mapping:"
 
 # create a mapping because apache uses different log levels than log4j eg. ERROR=>SEVERE
 function mapDoguLogLevel() {
-  echo "${SCRIPT_LOG_PREFIX} Mapping dogu specifig log level"
+  echo "${SCRIPT_LOG_PREFIX} Mapping dogu specific log level"
   currentLogLevel=$(doguctl config --default "${DEFAULT_LOG_LEVEL}" "${DEFAULT_LOGGING_KEY}")
   if [[ "$?" != "0" ]] ; then
     currentLogLevel="not found"

--- a/resources/logging.sh
+++ b/resources/logging.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# logging behaviour can be configured in /cas/logging/root with the following options <ERROR,WARN,INFO,DEBUG>
+# logging behaviour can be configured in logging/root with the following options <ERROR,WARN,INFO,DEBUG>
 DEFAULT_LOGGING_KEY="logging/root"
 LOG_LEVEL_ERROR="ERROR"; LOG_LEVEL_WARN="WARN"; LOG_LEVEL_INFO="INFO"; LOG_LEVEL_DEBUG="DEBUG"
 

--- a/resources/opt/apache-tomcat/cas.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/cas.properties.conf.tpl
@@ -31,3 +31,13 @@ tgt.maxTimeToLiveInSeconds= {{ .Config.GetOrDefault "session_tgt/max_time_to_liv
 # default value 10h
 tgt.timeToKillInSeconds={{ .Config.GetOrDefault "session_tgt/time_to_kill_in_seconds" "36000"}}
 
+
+# Control log levels via properties this overrides the log4j.xml config
+# default log level is WARN and can be changed via key /logging/root see dogu.json for further details
+logging.config=classpath:log4j.xml
+server.servlet.contextParameters.isLog4jAutoInitializationDisabled=true
+logging.level.org.apereo.cas={{ .Config.GetOrDefault "logging/root" "WARN"}}
+logging.level.org.apache.catalina={{ .Config.GetOrDefault "logging/root" "WARN"}}
+logging.level.de.triology.cas={{ .Config.GetOrDefault "logging/root" "WARN"}}
+logging.level.de.org.jasig={{ .Config.GetOrDefault "logging/root" "WARN"}}
+

--- a/resources/opt/apache-tomcat/cas.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/cas.properties.conf.tpl
@@ -30,14 +30,3 @@ tgt.maxTimeToLiveInSeconds= {{ .Config.GetOrDefault "session_tgt/max_time_to_liv
 
 # default value 10h
 tgt.timeToKillInSeconds={{ .Config.GetOrDefault "session_tgt/time_to_kill_in_seconds" "36000"}}
-
-
-# Control log levels via properties this overrides the log4j.xml config
-# default log level is WARN and can be changed via key /logging/root see dogu.json for further details
-logging.config=classpath:log4j.xml
-server.servlet.contextParameters.isLog4jAutoInitializationDisabled=true
-logging.level.org.apereo.cas={{ .Config.GetOrDefault "logging/root" "WARN"}}
-logging.level.org.apache.catalina={{ .Config.GetOrDefault "logging/root" "WARN"}}
-logging.level.de.triology.cas={{ .Config.GetOrDefault "logging/root" "WARN"}}
-logging.level.de.org.jasig={{ .Config.GetOrDefault "logging/root" "WARN"}}
-

--- a/resources/opt/apache-tomcat/conf/logging.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/conf/logging.properties.conf.tpl
@@ -13,30 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
-
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler
+.handlers = java.util.logging.ConsoleHandler
 
 ############################################################
 # Handler specific properties.
 # Describes specific configuration info for Handlers.
 ############################################################
-
-1catalina.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-
-2localhost.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-
-3manager.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
 
 java.util.logging.ConsoleHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
@@ -47,14 +30,6 @@ java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 # Provides extra control for each logger.
 ############################################################
 
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/resources/opt/apache-tomcat/conf/logging.properties.conf.tpl
+++ b/resources/opt/apache-tomcat/conf/logging.properties.conf.tpl
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+org.apache.catalina.util.LifecycleBase.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}
+# To see debug messages in TldLocationsCache, uncomment the following line:
+org.apache.jasper.compiler.TldLocationsCache.level = {{ .Env.Get "CATALINA_LOGLEVEL" }}

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -49,11 +49,9 @@ FQDN=$(doguctl config --global fqdn)
 
 echo "Getting ldap settings for template..."
 LDAP_TYPE=$(doguctl config ldap/ds_type)
-LDAP_SERVER=$(doguctl config ldap/server)
 LDAP_HOST=$(doguctl config ldap/host)
 LDAP_PORT=$(doguctl config ldap/port)
 LDAP_ATTRIBUTE_USERNAME=$(doguctl config ldap/attribute_id)
-LDAP_ATTRIBUTE_FULLNAME=$(doguctl config ldap/attribute_fullname)
 LDAP_ATTRIBUTE_MAIL=$(doguctl config ldap/attribute_mail)
 LDAP_ATTRIBUTE_GROUP=$(doguctl config ldap/attribute_group)
 LDAP_ENCRYPTION=$(doguctl config ldap/encryption) || LDAP_ENCRYPTION="none" # ssl, sslAny, startTLS, startTLSAny or none

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -21,7 +21,7 @@ function global_cfg_or_default {
   echo "${VALUE}"
 }
 
-# configure logging behaviour using the etcd property /cas/logging/root <ERROR,WARN,INFO,DEBUG>
+# configure logging behaviour using the etcd property logging/root <ERROR,WARN,INFO,DEBUG>
 source ./logging.sh
 
 MESSAGES_PROPERTIES_FILE="/opt/apache-tomcat/webapps/cas/WEB-INF/classes/messages.properties"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -26,6 +26,7 @@ function global_cfg_or_default {
 # If an error occurs in logging.sh the whole scripting quits because of -o errexit. Catching the sourced exit code
 # leads to an zero exit code which enables further error handling.
 loggingExitCode=0
+# shellcheck disable=SC1091
 source ./logging.sh || loggingExitCode=$?
 if [[ ${loggingExitCode} -ne 0 ]]; then
   echo "ERROR: An error occurred during the root log level evaluation.";

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -155,5 +155,7 @@ if [[ "$LDAP_TYPE" == 'embedded' ]]; then
   fi
 fi
 
+doguctl state ready
+
 echo "Starting cas..."
 exec su - cas -c "${CATALINA_SH} run"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -21,6 +21,9 @@ function global_cfg_or_default {
   echo "${VALUE}"
 }
 
+# configure logging behaviour using the etcd property /cas/logging/root <ERROR,WARN,INFO,DEBUG>
+source ./logging.sh
+
 MESSAGES_PROPERTIES_FILE="/opt/apache-tomcat/webapps/cas/WEB-INF/classes/messages.properties"
 CAS_PROPERTIES_TEMPLATE="/opt/apache-tomcat/cas.properties.conf.tpl"
 CAS_PROPERTIES="/opt/apache-tomcat/webapps/cas/WEB-INF/cas.properties"


### PR DESCRIPTION
use etcdkey **/cas/logging/root** to
configure the default log level of
cas. Supported levels are:
**<ERROR,WARN,INFO,DEBUG>** *default=WARN.
see **cas.properties.conf.tpl** for details

To configure the apache logging the
levels will be mapped to:
**<SEVERE,WARNING,INFO,FINE>**
see **logging.properties.conf.tpl**
for details

eg.
`cesapp edit-config cas
logging/root WARN`
`cat /var/log/docker/cas.log`