### PR TITLE
Activate Perf4J logger only if log level is INFO or DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,39 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Activate Perf4J logger only if log level is INFO or DEBUG; #62
 
 ## [v4.0.7.20-13] - 2020-12-17
-
 ### Fixed
 - bug where the `forgot_password_text`-key was never applied for some browsers (#60)
 
 ### Changed
-- update java base image to 8u252-1
+- Update java base image to 8u252-1
 
 ## [v4.0.7.20-12] - 2020-12-14
-
 ### Added
-
 - Ability to set memory limit via `cesapp edit-config`
 - Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#58)
 
 ## [v4.0.7.20-11] - 2020-11-19
-
 ### Added
-
 - add locales for de_DE and en_US
 
 ### Fixed
-
 - change server encoding so special characters will be decoded correctly (#56)
 
 ## [v4.0.7.20-10] - 2020-11-12
-
 ### Fixed
 - CAS bloated the log file after a dogu was uninstalled or marked as `absent` during a blueprint upgrade. (#54)
 
 ## [v4.0.7.20-9](https://github.com/cloudogu/cas/releases/tag/v4.0.7.20-9) - 2020-07-24
-
 ### Changed
 - Use doguctl validation for log level
 
@@ -47,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add automated release flow
 
 ## [v4.0.7.20-8](https://github.com/cloudogu/cas/releases/tag/v4.0.7.20-8) - 2020-04-08
-
 ### Added 
 
 A new CES registry key `logging/root` is evaluated to override the default root log level (#49). One of these values can be set in order to increase the log verbosity: `ERROR`, `WARN`, `INFO`, `DEBUG`. 
@@ -64,15 +57,12 @@ Tomcat log levels are mapped from the root log level as follows:
 | DEBUG | Everything equal or above FINE |
 
 ### Changed
-
-Under the hood we verify the Tomcat binary to spot (possibly) tampered Tomcat binaries during the build time. (#38)
+- Under the hood we verify the Tomcat binary to spot (possibly) tampered Tomcat binaries during the build time. (#38)
 
 ### Fixed
-
-PerformanceStats are no longer logged to the container filesystem for reasons of discoverability and performance. Instead they are logged to the usual CES logging facility. (#48)
+- PerformanceStats are no longer logged to the container filesystem for reasons of discoverability and performance. Instead they are logged to the usual CES logging facility. (#48)
 
 ## [v4.0.7.20-7](https://github.com/cloudogu/cas/releases/tag/v4.0.7.20-7) - 2020-03-12 
-
 ### Added
 * cas config etcd key `session_tgt/max_time_to_live_in_seconds` to configure maximum session timeout
 * cas config etcd key `session_tgt/time_to_kill_in_seconds` to configure idle session timeout

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.44.2', 'github.com/cloudogu/dogu-build-lib@v1.1.0'])
+@Library(['github.com/cloudogu/ces-build-lib@1.44.3', 'github.com/cloudogu/dogu-build-lib@v1.1.1'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/resources/etc/cas/conf/log4j.xml.tpl
+++ b/resources/etc/cas/conf/log4j.xml.tpl
@@ -67,6 +67,8 @@
     </appender>
 
     <!-- Loggers -->
+    {{$loglevel := .Config.GetOrDefault "logging/root" "WARN"}}
+    {{if eq $loglevel "INFO" "DEBUG"}}
     <!--
       The Perf4J logger. Note that org.perf4j.TimingLogger is the value of the
       org.perf4j.StopWatch.DEFAULT_LOGGER_NAME constant. Also, note that
@@ -75,10 +77,10 @@
       upstream loggers.
     -->
     <logger name="org.perf4j.TimingLogger" additivity="false">
-        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <level value="{{ $loglevel }}" />
         <appender-ref ref="CoalescingStatistics" />
     </logger>
-
+    {{end}}
     <!--
         WARNING: Setting the org.springframework logger to DEBUG displays debug information about
         the request parameter values being bound to the command objects.  This could expose your


### PR DESCRIPTION
As the logger does not seem to accept other log levels than INFO we have no choice but to deactivate it if the log level is ERROR or WARN.

Resolves #62