### PR TITLE
Add a logging/translation_messages configuration option to dogu.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add own log level configuration for translation logs; #64
+- Set default log level for translation related logs to ERROR; #64
 
 ## [v4.0.7.20-14] - 2021-01-11
 ### Fixed

--- a/dogu.json
+++ b/dogu.json
@@ -80,6 +80,21 @@
       }
     },
     {
+      "Name": "logging/translation_messages",
+      "Description": "Set the log level of translation concerned logs to one of ERROR, WARN, INFO, DEBUG.",
+      "Optional": true,
+      "Default": "ERROR",
+      "Validation": {
+        "Type": "ONE_OF",
+        "Values": [
+          "WARN",
+          "DEBUG",
+          "INFO",
+          "ERROR"
+        ]
+      }
+    },
+    {
       "Name": "container_config/memory_limit",
       "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,

--- a/resources/etc/cas/conf/log4j.xml.tpl
+++ b/resources/etc/cas/conf/log4j.xml.tpl
@@ -117,7 +117,7 @@
         The code [xxx] cannot be found in the language bundle for the locale [en_US]
     -->
     <logger name="org.jasig.cas.web.view.CasReloadableMessageBundle">
-        <level value='{{ .Config.GetOrDefault "logging/root" "WARN"}}' />
+        <level value='{{ .Config.GetOrDefault "logging/translation_messages" "ERROR"}}' />
         <appender-ref ref="console" />
     </logger>
 


### PR DESCRIPTION
The Option will mute unnecessary translation logs in production (default is 'ERROR') while still having a way to adjust the log level for translations. 
Resolves (#64)