### PR TITLE
Fix relative links in operations documentation

### DIFF
--- a/docs/operations/oauth_development_de.md
+++ b/docs/operations/oauth_development_de.md
@@ -8,9 +8,9 @@ Dieser wurde um das Interface `ICESServiceFactory` erweitert um die Erstellung v
 Ausgehend davon werden in den beiden Stages `CesServicesManagerStageDevelopment` und `CesServicesManagerStageProductive` 
 die neuen Factories die das Interface `ICESServiceFactory` implementiert genutzt um Services für OAuth, PersistantServices 
 und DoguServices zu erstellen.
-Neu ist ebenfalls das Package [de.triology.cas.services.oauth](../app/src/main/java/de/triology/cas/services/oauth). 
+Neu ist ebenfalls das Package [de.triology.cas.services.oauth](../../app/src/main/java/de/triology/cas/oauth). 
 Die enthaltenden Controller verwalten die Requests an die Endpunkte für OAuth-Requests 
-([/authorize](oauth/endpoint_authorize.md), [/accessToken](oauth/endpoint_accessToken.md), [/profile](oauth/endpoint_profile.md)). 
+([/authorize](endpoint_authorize_de.md), [/accessToken](endpoint_accessToken_de.md), [/profile](endpoint_profile_de.md)). 
 Um alle nötigen Informationen zu sammeln wurde außerdem die Klasse `RegestryEtcd` dahingehend erwetert, 
 dass die Informationen die für OAuth Services benötigt werden (ClientId und Secret-Hash) aus dem etcd ausgelesen werden können.
 

--- a/docs/operations/oauth_development_en.md
+++ b/docs/operations/oauth_development_en.md
@@ -9,9 +9,9 @@ Dieser wurde um das Interface `ICESServiceFactory` erweitert um die Erstellung v
 Ausgehend davon werden in den beiden Stages `CesServicesManagerStageDevelopment` und `CesServicesManagerStageProductive` 
 die neuen Factories die das Interface `ICESServiceFactory` implementiert genutzt um Services für OAuth, PersistantServices 
 und DoguServices zu erstellen.
-Neu ist ebenfalls das Package [de.triology.cas.services.oauth](../app/src/main/java/de/triology/cas/services/oauth). 
+Neu ist ebenfalls das Package [de.triology.cas.services.oauth](../../app/src/main/java/de/triology/cas/oauth). 
 Die enthaltenden Controller verwalten die Requests an die Endpunkte für OAuth-Requests 
-([/authorize](oauth/endpoint_authorize.md), [/accessToken](oauth/endpoint_accessToken.md), [/profile](oauth/endpoint_profile.md)). 
+([/authorize](endpoint_authorize_en.md), [/accessToken](endpoint_accessToken_en.md), [/profile](endpoint_profile_en.md)). 
 Um alle nötigen Informationen zu sammeln wurde außerdem die Klasse `RegestryEtcd` dahingehend erwetert, 
 dass die Informationen die für OAuth Services benötigt werden (ClientId und Secret-Hash) aus dem etcd ausgelesen werden können.
 

--- a/docs/operations/oauth_guide_de.md
+++ b/docs/operations/oauth_guide_de.md
@@ -15,7 +15,7 @@ Dafür kann die Aufforderung eines CAS-Service Account in der `dogu.json` des be
 ]
 ```
 
-Die Credentials des Service Accounts werden zufällig generiert (siehe [create-sa.sh](../resources/create-sa.sh)) 
+Die Credentials des Service Accounts werden zufällig generiert (siehe [create-sa.sh](../../resources/create-sa.sh)) 
 und verschlüsselt im etcd unter dem Pfad `/config/<dogu>/sa-cas/oauth_client_id` und `/config/<dogu>/sa-cas/oauth_client_secret` hinterlegt.
 Die credentials setzten sich aus der `CLIENT_ID` und dem `CLIENT_SECRET` zusammen. 
 Für den CAS wird das `CLIENT_SECRET` als Hash im __etcd__ unter dem Pfad `/config/cas/service_accounts/<CLIENT_ID>` abgelegt.
@@ -24,9 +24,9 @@ Für den CAS wird das `CLIENT_SECRET` als Hash im __etcd__ unter dem Pfad `/conf
 
 Die folgenden Schritte beschreiben einen erfolgreichen Ablauf der OAuth-Authentifizierung. 
 
-1. Anfordern eines Kurzzeit-Tokens: [Authorize-Endpunkt](oauth/endpoint_authorize.md)
-2. Kurzzeittoken gegen ein Langzeittoken tauschen: [AccessToken-Endpunkt](oauth/endpoint_accessToken.md)    
+1. Anfordern eines Kurzzeit-Tokens: [Authorize-Endpunkt](endpoint_authorize_de.md)
+2. Kurzzeittoken gegen ein Langzeittoken tauschen: [AccessToken-Endpunkt](endpoint_accessToken_de.md)    
 3. Langzeittoken kann nun zu Authentifizierung gegen Ressourcen benutzen werden. 
-   Derzeit bietet CAS nur das Profil der User als Resource an: [Profil-Endpunkt](oauth/endpoint_profile.md)
+   Derzeit bietet CAS nur das Profil der User als Resource an: [Profil-Endpunkt](endpoint_profile_de.md)
 
 ![CesServiceFactory](figures/sequenzediagramm_oauth.png)

--- a/docs/operations/oauth_guide_en.md
+++ b/docs/operations/oauth_guide_en.md
@@ -18,7 +18,7 @@ To do this, the request for a CAS service account can be stored in the `dogu.jso
 ]
 ```
 
-The credentials of the service account are randomly generated (see [create-sa.sh](../resources/create-sa.sh)) 
+The credentials of the service account are randomly generated (see [create-sa.sh](../../resources/create-sa.sh))
 and stored encrypted in etcd under the path `/config/<dogu>/sa-cas/oauth_client_id` and `/config/<dogu>/sa-cas/oauth_client_secret`.
 The credentials are composed of the `CLIENT_ID` and the `CLIENT_SECRET`. 
 For the CAS, the `CLIENT_SECRET` is stored as a hash in the __etcd__ under the path `/config/cas/service_accounts/<CLIENT_ID>`.
@@ -27,9 +27,9 @@ For the CAS, the `CLIENT_SECRET` is stored as a hash in the __etcd__ under the p
 
 The following steps describe a successful OAuth authentication flow. 
 
-1. request a short-term token: [authorize-endpoint](oauth/endpoint_authorize.md)
-2. swap short-term token for long-term token: [AccessToken endpoint](oauth/endpoint_accessToken.md).    
+1. request a short-term token: [authorize-endpoint](endpoint_authorize_en.md)
+2. swap short-term token for long-term token: [AccessToken endpoint](endpoint_accessToken_en.md).    
 3. long term token can now be used to authenticate against resources. 
-   Currently CAS only offers user's profile as resource: [profile endpoint](oauth/endpoint_profile.md)
+   Currently CAS only offers user's profile as resource: [profile endpoint](endpoint_profile_en.md)
 
-![CesServiceFactory](figures/sequence_diagramm_oauth.png)
+![CesServiceFactory](figures/sequenzediagramm_oauth.png)


### PR DESCRIPTION
The links of docs inside the operations folder now point to the correct files in the repo.