### PR TITLE
#150 Add custom service matching strategy. In kubernetes context the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- fix proxy ticket validation with services contain ports (#150)
 
 ## [v6.5.3-1] - 2022-04-26
+### Changed
 - Upgrade cas to 6.5.3 (#147)
 
 ## [v6.5.2-1] - 2022-04-13

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,13 +114,14 @@ dependencies {
     implementation "org.apereo.cas:cas-server-core-api-protocol:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-api-configuration-model:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-authentication-api:${project.'cas.version'}"
-    implementation "org.apereo.cas:cas-server-core-authentication-throttle:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-authentication-attributes:${project.'cas.version'}"
+    implementation "org.apereo.cas:cas-server-core-authentication-throttle:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-logout:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-logout-api:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-services:${project.'cas.version'}"
-    implementation "org.apereo.cas:cas-server-core-services-registry:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-services-api:${project.'cas.version'}"
+    implementation "org.apereo.cas:cas-server-core-services-authentication:${project.'cas.version'}"
+    implementation "org.apereo.cas:cas-server-core-services-registry:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-util:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-core-web-api:${project.'cas.version'}"
 
@@ -144,6 +145,7 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-swagger:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-support-throttle:${project.'cas.version'}"
     implementation "org.apereo.cas:cas-server-support-throttle-core:${project.'cas.version'}"
+
 
     implementation 'org.mousio:etcd4j:2.11.0'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/app/src/main/java/de/triology/cas/services/CesServiceMatchingStrategy.java
+++ b/app/src/main/java/de/triology/cas/services/CesServiceMatchingStrategy.java
@@ -1,0 +1,42 @@
+package de.triology.cas.services;
+
+import lombok.val;
+import org.apereo.cas.authentication.principal.DefaultServiceMatchingStrategy;
+import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.util.LoggingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Matching strategy for comparing services. It generally behaves like the {@link DefaultServiceMatchingStrategy}
+ * but omits service ports
+ */
+public class CesServiceMatchingStrategy extends DefaultServiceMatchingStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(CesServiceMatchingStrategy.class);
+
+    public CesServiceMatchingStrategy(ServicesManager servicesManager) {
+        super(servicesManager);
+    }
+
+    @Override
+    public boolean matches(final Service service, final Service serviceToMatch) {
+        try {
+            val thisUrl = removePortFromUrl(URLDecoder.decode(service.getId(), StandardCharsets.UTF_8.name()));
+            val serviceUrl = removePortFromUrl(URLDecoder.decode(serviceToMatch.getId(), StandardCharsets.UTF_8.name()));
+
+            LOG.debug("Decoded urls and comparing [{}] with [{}]", thisUrl, serviceUrl);
+            return thisUrl.equalsIgnoreCase(serviceUrl);
+        } catch (final Exception e) {
+            LoggingUtils.error(LOG, e);
+        }
+        return false;
+    }
+
+    private String removePortFromUrl(String service) {
+        return service.replaceFirst(":\\d+", "");
+    }
+}

--- a/app/src/main/java/de/triology/cas/services/CesServicesSpringConfiguration.java
+++ b/app/src/main/java/de/triology/cas/services/CesServicesSpringConfiguration.java
@@ -1,6 +1,7 @@
 package de.triology.cas.services;
 
 import mousio.etcd4j.EtcdClient;
+import org.apereo.cas.authentication.principal.ServiceMatchingStrategy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.ChainingServicesManager;
 import org.apereo.cas.services.DefaultChainingServicesManager;
@@ -8,11 +9,14 @@ import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.ServicesManagerExecutionPlanConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,6 +61,13 @@ public class CesServicesSpringConfiguration implements ServicesManagerExecutionP
         DefaultChainingServicesManager chain = new DefaultChainingServicesManager();
         chain.registerServiceManager(configureServicesManager());
         return chain;
+    }
+
+    @Bean(name = "serviceMatchingStrategy")
+    public ServiceMatchingStrategy serviceMatchingStrategy(
+            @Qualifier(ServicesManager.BEAN_NAME)
+            final ServicesManager servicesManager) {
+        return new CesServiceMatchingStrategy(servicesManager);
     }
 
     @Override

--- a/app/src/test/java/de/triology/cas/services/CesServiceMatchingStrategyTest.java
+++ b/app/src/test/java/de/triology/cas/services/CesServiceMatchingStrategyTest.java
@@ -1,0 +1,82 @@
+package de.triology.cas.services;
+
+import org.apereo.cas.authentication.principal.Service;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CesServiceMatchingStrategyTest {
+
+    @Test
+    public void matchesOnePort() throws UnsupportedEncodingException{
+        // given
+        String serviceUrl = URLEncoder.encode("https://192.168.56.2/scm/api/v2/cas/auth/", StandardCharsets.UTF_8.name());
+        Service service = new TestService(serviceUrl);
+        String serviceToMatchUrl = URLEncoder.encode("https://192.168.56.2:443/scm/api/v2/cas/auth/", StandardCharsets.UTF_8.name());
+        Service serviceToMatch = new TestService(serviceToMatchUrl);
+        CesServiceMatchingStrategy strategy = new CesServiceMatchingStrategy(null);
+
+        // when
+        boolean result = strategy.matches(service, serviceToMatch);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    public void matchesBothPorts() throws UnsupportedEncodingException{
+        // given
+        String serviceUrl = URLEncoder.encode("https://192.168.56.1:80/scm/auth", StandardCharsets.UTF_8.name());
+        Service service = new TestService(serviceUrl);
+        String serviceToMatchUrl = URLEncoder.encode("https://192.168.56.1:443/scm/auth", StandardCharsets.UTF_8.name());
+        Service serviceToMatch = new TestService(serviceToMatchUrl);
+        CesServiceMatchingStrategy strategy = new CesServiceMatchingStrategy(null);
+
+        // when
+        boolean result = strategy.matches(service, serviceToMatch);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    public void matchesNoPorts() throws UnsupportedEncodingException{
+        // given
+        String serviceUrl = URLEncoder.encode("https://192.168.56.1/scm/auth", StandardCharsets.UTF_8.name());
+        Service service = new TestService(serviceUrl);
+        String serviceToMatchUrl = URLEncoder.encode("https://192.168.56.1/scm/auth", StandardCharsets.UTF_8.name());
+        Service serviceToMatch = new TestService(serviceToMatchUrl);
+        CesServiceMatchingStrategy strategy = new CesServiceMatchingStrategy(null);
+
+        // when
+        boolean result = strategy.matches(service, serviceToMatch);
+
+        // then
+        assertTrue(result);
+    }
+}
+
+class TestService implements Service {
+
+    private final String id;
+
+    public TestService(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public void setAttributes(Map<String, List<Object>> attributes) {
+
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+}


### PR DESCRIPTION
…proxy controller adds 'Forwarded' headers which results in service urls with ports sent by scm. With the default matching strategy the comparison would fail.

Resolves #150 