### PR TITLE
#207 Fix edge-case-bug where the post-upgrade-script would fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The post-upgrade-script would fail in a specific edge-case situation [#207]
+  - Affected System: Cloudogu EcoSystem 'Classic' (Pre-Multinode)
+  - Affected versions: `7.0.5.1-4` and `7.0.5.1-5`
+  - When an OAuth/OIDC-Dogu was installed and then uninstalled, the post-upgrade script would fail during an upgrade from CAS versions below `7.0.5.1-4`.
+  - This means that a directory `/config/cas/service_accounts/<type>` had to exist, but be empty (where `<type>` can be `oauth` or `oidc`).
+  - Additionally prevent similar cases.
 
 ## [v7.0.5.1-5] - 2024-08-20
 ### Fixed


### PR DESCRIPTION
Affected System: Cloudogu EcoSystem 'Classic' (Pre-Multinode)
Affected versions: `7.0.5.1-4` and `7.0.5.1-5`

When an OAuth/OIDC-Dogu was installed and then uninstalled, the post-upgrade script would fail during an upgrade from CAS versions below `7.0.5.1-4`. This means that a directory `/config/cas/service_accounts/<type>` had to exist, but be empty (where `<type>` can be `oauth` or `oidc`).

Additionally, this should prevent similar cases as well.

Resolves #207 