### PR TITLE
#209 Delete old service accounts for a dogu when creating a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- When a dogu changes its CAS service account type, the old service account does not get deleted. [#209]
+  - This causes problems with e.g. Portainer which swapped from oauth to a plain cas service account.
 
 ## [v7.0.5.1-6] - 2024-08-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- When a dogu changes its CAS service account type, the old service account does not get deleted. [#209]
-  - This causes problems with e.g. Portainer which swapped from oauth to a plain cas service account.
+- When a dogu changes its CAS service account type, the old service account gets deleted now [#209]
+  - This bug caused problems with e.g. Portainer which swapped from oauth to a plain cas service account.
 
 ## [v7.0.5.1-6] - 2024-08-27
 ### Fixed

--- a/batsTests/create-sa.bats
+++ b/batsTests/create-sa.bats
@@ -1,0 +1,80 @@
+#! /bin/bash
+# Bind an unbound BATS variables that fail all tests when combined with 'set -o nounset'
+export BATS_TEST_START_TIME="0"
+export BATSLIB_FILE_PATH_REM=""
+export BATSLIB_FILE_PATH_ADD=""
+
+load '/workspace/target/bats_libs/bats-support/load.bash'
+load '/workspace/target/bats_libs/bats-assert/load.bash'
+load '/workspace/target/bats_libs/bats-mock/load.bash'
+load '/workspace/target/bats_libs/bats-file/load.bash'
+
+setup_file() {
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  export STARTUP_DIR=/workspace/resources
+  export WORKDIR=/workspace
+
+  export PATH="${BATS_TMPDIR}:${PATH}"
+}
+
+setup() {
+  source /workspace/resources/create-sa.sh
+
+  doguctl="$(mock_create)"
+  export doguctl
+  ln -s "${doguctl}" "${BATS_TMPDIR}/doguctl"
+
+  set +o errexit
+  set +o nounset
+  set +o pipefail
+}
+
+teardown() {
+  unset doguctl
+  rm "${BATS_TMPDIR}/doguctl"
+}
+
+@test 'deleteOldServiceAccounts() should try to remove all but cas' {
+  mock_set_output "${doguctl}" "DEFAULT" '1'
+  mock_set_output "${doguctl}" "my-secret" '2'
+
+  run deleteOldServiceAccounts "my_dogu" "cas"
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${doguctl}")" '3'
+
+  assert_equal "$(mock_get_call_args "${doguctl}" '1')" 'config --default DEFAULT service_accounts/oidc/my_dogu/secret'
+  assert_equal "$(mock_get_call_args "${doguctl}" '2')" 'config --default DEFAULT service_accounts/oauth/my_dogu/secret'
+  assert_equal "$(mock_get_call_args "${doguctl}" '3')" 'config --rm service_accounts/oauth/my_dogu/secret'
+}
+
+@test 'deleteOldServiceAccounts() should try to remove all but oidc' {
+  mock_set_output "${doguctl}" "DEFAULT" '1'
+  mock_set_output "${doguctl}" "my-secret" '2'
+
+  run deleteOldServiceAccounts "my_dogu" "oidc"
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${doguctl}")" '3'
+
+  assert_equal "$(mock_get_call_args "${doguctl}" '1')" 'config --default DEFAULT service_accounts/cas/my_dogu/created'
+  assert_equal "$(mock_get_call_args "${doguctl}" '2')" 'config --default DEFAULT service_accounts/oauth/my_dogu/secret'
+  assert_equal "$(mock_get_call_args "${doguctl}" '3')" 'config --rm service_accounts/oauth/my_dogu/secret'
+}
+
+@test 'deleteOldServiceAccounts() should try to remove all but oauth' {
+  mock_set_output "${doguctl}" "my-secret" '1'
+  mock_set_output "${doguctl}" "DEFAULT" '2'
+
+  run deleteOldServiceAccounts "my_dogu" "oauth"
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${doguctl}")" '3'
+
+  assert_equal "$(mock_get_call_args "${doguctl}" '1')" 'config --default DEFAULT service_accounts/cas/my_dogu/created'
+  assert_equal "$(mock_get_call_args "${doguctl}" '2')" 'config --rm service_accounts/cas/my_dogu/created'
+  assert_equal "$(mock_get_call_args "${doguctl}" '3')" 'config --default DEFAULT service_accounts/oidc/my_dogu/secret'
+}

--- a/resources/create-sa.sh
+++ b/resources/create-sa.sh
@@ -3,43 +3,76 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-{
-  if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-    echo "usage create-sa.sh account_type [logout_uri] servicename"
-    exit 1
-  fi
+deleteOldServiceAccounts() {
+  local serviceName accountType allTypes typesToDelete
+  serviceName="${1}"
+  accountType="${2}"
 
-  TYPE="${1}"
-  SERVICE="${*: -1}"
-  if [ "$#" -eq 3 ]; then
-    LOGOUT_URI="${2}"
-  fi
+  allTypes=("cas" "oidc" "oauth")
+  typesToDelete=( "${allTypes[@]/$accountType}" )
+  for type in "${typesToDelete[@]}"; do
+    if [ "${type}" == "cas" ]; then
+      rmConfigIfExists "service_accounts/${type}/${serviceName}/created"
+    else
+      rmConfigIfExists "service_accounts/${type}/${serviceName}/secret"
+    fi
+  done
+}
 
-  echo "Create sa for ${SERVICE} with account type: ${TYPE}..."
+rmConfigIfExists() {
+  local key value
+  key="${1}"
+  value="$(doguctl config --default "DEFAULT" "${key}")"
+  if [ "${value}" != "DEFAULT" ]; then
+    doguctl config --rm "${key}"
+  fi
+}
+
+createServiceAccount() {
+  {
+    if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+      echo "usage create-sa.sh account_type [logout_uri] servicename"
+      exit 1
+    fi
+
+    TYPE="${1}"
+    SERVICE="${*: -1}"
+    if [ "$#" -eq 3 ]; then
+      LOGOUT_URI="${2}"
+    fi
+
+    echo "Create sa for ${SERVICE} with account accountType: ${TYPE}..."
+
+    if [ "${TYPE}" == "oidc" ] || [ "${TYPE}" == "oauth" ]; then
+      CLIENT_SECRET=$(doguctl random -l 16)
+      CLIENT_SECRET_HASH=$(echo -n "${CLIENT_SECRET}" | sha256sum | awk '{print $1}')
+
+      doguctl config "service_accounts/${TYPE}/${SERVICE}/secret" "${CLIENT_SECRET_HASH}"
+    elif [ "${TYPE}" == "cas" ]; then
+      # Set value `created` because doguctl requires a value to be set
+      doguctl config "service_accounts/${TYPE}/${SERVICE}/created" "true"
+    else
+      echo "only the account_types: oidc, oauth, cas are allowed"
+      exit 1
+    fi
+
+    deleteOldServiceAccounts "${SERVICE}" "${TYPE}"
+
+    if [ -n "${LOGOUT_URI+x}" ]; then
+        doguctl config "service_accounts/${TYPE}/${SERVICE}/logout_uri" "${LOGOUT_URI}"
+    fi
+
+  } >/dev/null 2>&1
+
+  # print client-id so that the service-account can be removed again
+  echo "${TYPE}_client_id: ${SERVICE}"
 
   if [ "${TYPE}" == "oidc" ] || [ "${TYPE}" == "oauth" ]; then
-    CLIENT_SECRET=$(doguctl random -l 16)
-    CLIENT_SECRET_HASH=$(echo -n "${CLIENT_SECRET}" | sha256sum | awk '{print $1}')
-
-    doguctl config "service_accounts/${TYPE}/${SERVICE}/secret" "${CLIENT_SECRET_HASH}"
-  elif [ "${TYPE}" == "cas" ]; then
-    # Set value `created` because doguctl requires a value to be set
-    doguctl config "service_accounts/${TYPE}/${SERVICE}/created" "true"
-  else
-    echo "only the account_types: oidc, oauth, cas are allowed"
-    exit 1
+    # print OAuth credentials for the service
+    echo "${TYPE}_client_secret: ${CLIENT_SECRET}"
   fi
+}
 
-  if [ -n "${LOGOUT_URI+x}" ]; then
-      doguctl config "service_accounts/${TYPE}/${SERVICE}/logout_uri" "${LOGOUT_URI}"
-  fi
-
-} >/dev/null 2>&1
-
-# print client-id so that the service-account can be removed again
-echo "${TYPE}_client_id: ${SERVICE}"
-
-if [ "${TYPE}" == "oidc" ] || [ "${TYPE}" == "oauth" ]; then
-  # print OAuth credentials for the service
-  echo "${TYPE}_client_secret: ${CLIENT_SECRET}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  createServiceAccount "$@"
 fi


### PR DESCRIPTION
When a dogu changes its CAS service account type,
the old service account does not get deleted.
This causes problems with e.g. Portainer which swapped from oauth to a plain cas service account.
This fixes that.

Resolves #209 