### PR TITLE
# 228 replace \-character with [] in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix configuration for delegated authentication with OIDC [#222]
+- Fix ServiceIdFQDN regex by changing illegal url characters [#228]
 
 ## [v7.0.8-3] - 2024-10-11
 ### Changed

--- a/app/src/main/java/de/triology/cas/services/dogu/CesDoguServiceFactory.java
+++ b/app/src/main/java/de/triology/cas/services/dogu/CesDoguServiceFactory.java
@@ -46,6 +46,6 @@ public class CesDoguServiceFactory implements CesServiceFactory {
             return "";
         }
 
-        return "((?i)" + fqdn.replace(".", "\\.") + ")";
+        return "((?i)" + fqdn.replace(".", "[.]") + ")";
     }
 }


### PR DESCRIPTION
\\-character is not allowed in urls. Replace \\. it with [.], which also matches a .-character