### PR TITLE
[#233] Prevent logging of invalid login credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix configuration for delegated authentication with OIDC [#222]
+- Prevent logging of invalid login credentials [#233]
 
 ## [v7.0.8-3] - 2024-10-11
 ### Changed

--- a/app/etc/cas/config/log4j2.xml
+++ b/app/etc/cas/config/log4j2.xml
@@ -67,6 +67,10 @@
             <LoggingHandlerPasswordRewritePolicy />
             <AppenderRef ref="casConsole" />
         </Rewrite>
+        <Rewrite name="misspelledPasswordRewritePolicy" >
+            <MisspelledPasswordRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
     </Appenders>
     <Loggers>
         <!-- If adding a Logger with level set higher than ${sys:ces.log.level}, make category as selective as possible -->
@@ -103,6 +107,9 @@
         </AsyncLogger>
         <AsyncLogger name="io.netty.handler.logging.LoggingHandler" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="loggingHandlerPasswordRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="misspelledPasswordRewritePolicy"/>
         </AsyncLogger>
 
         <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->

--- a/app/etc/cas/config/log4j2.xml
+++ b/app/etc/cas/config/log4j2.xml
@@ -71,6 +71,14 @@
             <MisspelledPasswordRewritePolicy />
             <AppenderRef ref="casConsole" />
         </Rewrite>
+        <Rewrite name="defaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy" >
+            <DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
+        <Rewrite name="requestResponseBodyMethodProcessorRewritePolicy" >
+            <RequestResponseBodyMethodProcessorRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
     </Appenders>
     <Loggers>
         <!-- If adding a Logger with level set higher than ${sys:ces.log.level}, make category as selective as possible -->
@@ -108,8 +116,14 @@
         <AsyncLogger name="io.netty.handler.logging.LoggingHandler" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="loggingHandlerPasswordRewritePolicy"/>
         </AsyncLogger>
-        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+        <AsyncLogger name="org.apereo.cas.web" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="misspelledPasswordRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="defaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="requestResponseBodyMethodProcessorRewritePolicy"/>
         </AsyncLogger>
 
         <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->

--- a/app/src/main/java/de/triology/cas/logging/DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy.java
+++ b/app/src/main/java/de/triology/cas/logging/DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy.java
@@ -1,0 +1,42 @@
+package de.triology.cas.logging;
+
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+@Plugin(
+        name = "DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy",
+        category = "Core",
+        elementType = "rewritePolicy",
+        printObject = true
+)
+/*
+ * Password rewriter for class org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer.
+ */
+public final class DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy extends AbstractCASPasswordRewritePolicy {
+    private static final String PARAMETER_PASSWORD_TEXT = "'password' ->";
+
+    @PluginFactory
+    public static DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy createPolicy() {
+        return new DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy();
+    }
+
+    private DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy() {
+        //
+    }
+
+    @Override
+    protected String getPasswordFlag() {
+        return PARAMETER_PASSWORD_TEXT;
+    }
+
+    @Override
+    protected String replacePasswordValue(String originMessage) {
+        String truncatedMessage = null;
+
+        if (originMessage != null) {
+            truncatedMessage = originMessage.replaceAll("'password' ->.*,\\s*'exec", "'password' -> '******', 'exec");
+        }
+
+        return truncatedMessage;
+    }
+}

--- a/app/src/main/java/de/triology/cas/logging/MisspelledPasswordRewritePolicy.java
+++ b/app/src/main/java/de/triology/cas/logging/MisspelledPasswordRewritePolicy.java
@@ -1,0 +1,42 @@
+package de.triology.cas.logging;
+
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+@Plugin(
+        name = "MisspelledPasswordRewritePolicy",
+        category = "Core",
+        elementType = "rewritePolicy",
+        printObject = true
+)
+/*
+ * Password rewriter for class org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer.
+ */
+public final class MisspelledPasswordRewritePolicy extends AbstractCASPasswordRewritePolicy {
+    private static final String PARAMETER_PASSWORD_TEXT = "password=";
+
+    @PluginFactory
+    public static MisspelledPasswordRewritePolicy createPolicy() {
+        return new MisspelledPasswordRewritePolicy();
+    }
+
+    private MisspelledPasswordRewritePolicy() {
+        //
+    }
+
+    @Override
+    protected String getPasswordFlag() {
+        return PARAMETER_PASSWORD_TEXT;
+    }
+
+    @Override
+    protected String replacePasswordValue(String originMessage) {
+        String truncatedMessage = null;
+
+        if (originMessage != null) {
+            truncatedMessage = originMessage.replaceAll("password=\\[.*\\],\\s*exec", "password=[******], exec");
+        }
+
+        return truncatedMessage;
+    }
+}

--- a/app/src/main/java/de/triology/cas/logging/RequestResponseBodyMethodProcessorRewritePolicy.java
+++ b/app/src/main/java/de/triology/cas/logging/RequestResponseBodyMethodProcessorRewritePolicy.java
@@ -1,0 +1,42 @@
+package de.triology.cas.logging;
+
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+@Plugin(
+        name = "RequestResponseBodyMethodProcessorRewritePolicy",
+        category = "Core",
+        elementType = "rewritePolicy",
+        printObject = true
+)
+/*
+ * Password rewriter for class org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.
+ */
+public final class RequestResponseBodyMethodProcessorRewritePolicy extends AbstractCASPasswordRewritePolicy {
+    private static final String PARAMETER_PASSWORD_TEXT = "password=";
+
+    @PluginFactory
+    public static RequestResponseBodyMethodProcessorRewritePolicy createPolicy() {
+        return new RequestResponseBodyMethodProcessorRewritePolicy();
+    }
+
+    private RequestResponseBodyMethodProcessorRewritePolicy() {
+        //
+    }
+
+    @Override
+    protected String getPasswordFlag() {
+        return PARAMETER_PASSWORD_TEXT;
+    }
+
+    @Override
+    protected String replacePasswordValue(String originMessage) {
+        String truncatedMessage = null;
+
+        if (originMessage != null) {
+            truncatedMessage = originMessage.replaceAll("password=.*\\]\\}\\]", "password=******]}]");
+        }
+
+        return truncatedMessage;
+    }
+}

--- a/resources/etc/cas/config/log4j2.xml.tpl
+++ b/resources/etc/cas/config/log4j2.xml.tpl
@@ -67,6 +67,10 @@
             <LoggingHandlerPasswordRewritePolicy />
             <AppenderRef ref="casConsole" />
         </Rewrite>
+        <Rewrite name="misspelledPasswordRewritePolicy" >
+            <MisspelledPasswordRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
     </Appenders>
     <Loggers>
         <!-- If adding a Logger with level set higher than ${sys:ces.log.level}, make category as selective as possible -->
@@ -103,6 +107,9 @@
         </AsyncLogger>
         <AsyncLogger name="io.netty.handler.logging.LoggingHandler" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="loggingHandlerPasswordRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="misspelledPasswordRewritePolicy"/>
         </AsyncLogger>
 
         <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->

--- a/resources/etc/cas/config/log4j2.xml.tpl
+++ b/resources/etc/cas/config/log4j2.xml.tpl
@@ -71,6 +71,14 @@
             <MisspelledPasswordRewritePolicy />
             <AppenderRef ref="casConsole" />
         </Rewrite>
+        <Rewrite name="defaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy" >
+            <DefaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
+        <Rewrite name="requestResponseBodyMethodProcessorRewritePolicy" >
+            <RequestResponseBodyMethodProcessorRewritePolicy />
+            <AppenderRef ref="casConsole" />
+        </Rewrite>
     </Appenders>
     <Loggers>
         <!-- If adding a Logger with level set higher than ${sys:ces.log.level}, make category as selective as possible -->
@@ -108,8 +116,14 @@
         <AsyncLogger name="io.netty.handler.logging.LoggingHandler" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="loggingHandlerPasswordRewritePolicy"/>
         </AsyncLogger>
-        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+        <AsyncLogger name="org.apereo.cas.web" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
             <AppenderRef ref="misspelledPasswordRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.apereo.cas.web.flow.DefaultDelegatedClientIdentityProviderConfigurationProducer" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="defaultDelegatedClientIdentityProviderConfigurationProducerRewritePolicy"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor" level="${sys:ces.log.level}" includeLocation="true" additivity="false">
+            <AppenderRef ref="requestResponseBodyMethodProcessorRewritePolicy"/>
         </AsyncLogger>
 
         <!-- All Loggers inherit appenders specified here, unless additivity="false" on the Logger -->


### PR DESCRIPTION
because the DefaultDelegatedClientIdentityProviderConfigurationProducer of apereo.cas would print invalid credentials at an invalid login attempt, the password in the log event need to be masked to prevent guessing of actual credentials