### PR TITLE
Feature/244 restrict access for delegated authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add configuration for `allowed_groups` and `initial_admin_user` in delegated authentication 
 
+### Changed
+- Update java base image to 21.0.5-1
+- Update Tomcat to 10.1.34
 
 ## [v7.0.8-9] - 2024-12-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add configuration for `allowed_groups` and `initial_admin_user` in delegated authentication 
+
 
 ## [v7.0.8-9] - 2024-12-20
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TOMCAT_MAJOR_VERSION=10
-ARG TOMCAT_VERSION=10.1.26
-ARG TOMCAT_TARGZ_SHA256=f73f76760137833b3305dfb18ed174f87feac3ab78f65289a0835a851d7cfeb2
+ARG TOMCAT_VERSION=10.1.34
+ARG TOMCAT_TARGZ_SHA256=f799541380bfff2b674cefd86c5376d2d7d566b3a2e7c4579d2b491de8ec6c36
 
 FROM eclipse-temurin:21-jdk-alpine AS builder
 
@@ -41,7 +41,7 @@ RUN apk update && apk add wget && wget -O  "apache-tomcat-${TOMCAT_VERSION}.tar.
 
 
 # registry.cloudogu.com/official/cas
-FROM registry.cloudogu.com/official/java:21.0.4-4
+FROM registry.cloudogu.com/official/java:21.0.5-1
 
 LABEL NAME="official/cas" \
       VERSION="7.0.8-9" \

--- a/app/src/main/java/de/triology/cas/ldap/UserManager.java
+++ b/app/src/main/java/de/triology/cas/ldap/UserManager.java
@@ -157,7 +157,7 @@ public class UserManager {
     }
 
     private String createDnForGroup(String groupName) {
-        return CesInternalLdapUser.CnAttribute + "=" + groupName + "," + this.groupBaseDN;
+        return GroupCnAttribute + "=" + groupName + "," + this.groupBaseDN;
     }
 
     private SearchRequest createGetUserRequest(String uid) {

--- a/app/src/main/java/de/triology/cas/ldap/UserManager.java
+++ b/app/src/main/java/de/triology/cas/ldap/UserManager.java
@@ -132,7 +132,7 @@ public class UserManager {
      * Adds the given user to the given group in LDAP
      *
      * @param user      the user to add
-     * @param groupName the name of the group to add the use to
+     * @param groupName the name of the group to add the user to
      * @throws CesLdapException for errors in LDAP
      */
     public void addUserToGroup(CesInternalLdapUser user, String groupName) throws CesLdapException {

--- a/app/src/main/java/de/triology/cas/ldap/UserManager.java
+++ b/app/src/main/java/de/triology/cas/ldap/UserManager.java
@@ -11,17 +11,27 @@ public class UserManager {
     public static final String LDAP_TRUE = "TRUE";
     public static final String LDAP_FALSE = "FALSE";
 
+    public static final String GroupOu = "Groups";
+    public static final String GroupCnAttribute = "cn";
+    public static final String GroupMemberAttribute = "member";
+
     public static final String ObjectClassAttributeName = "objectClass";
 
-    private final String baseDN;
+    private final String userBaseDN;
+    private final String groupBaseDN;
     private final LdapOperationFactory operationFactory;
 
     /**
      * Creates a new Usermanager that can load, create and update {@link CesInternalLdapUser}s.
      */
-    public UserManager(String baseDN, LdapOperationFactory operationFactory) {
-        this.baseDN = baseDN;
+    public UserManager(String userBaseDN, LdapOperationFactory operationFactory) {
+        this.userBaseDN = userBaseDN;
+        this.groupBaseDN = createGroupBaseDNFromBaseDN(userBaseDN);
         this.operationFactory = operationFactory;
+    }
+
+    private static String createGroupBaseDNFromBaseDN(String userBaseDN) {
+        return userBaseDN.replaceFirst("(?<=ou=)[^,]+(?=,)", GroupOu);
     }
 
     /**
@@ -118,15 +128,43 @@ public class UserManager {
         }
     }
 
+    /**
+     * Adds the given user to the given group in LDAP
+     *
+     * @param user      the user to add
+     * @param groupName the name of the group to add the use to
+     * @throws CesLdapException for errors in LDAP
+     */
+    public void addUserToGroup(CesInternalLdapUser user, String groupName) throws CesLdapException {
+        try {
+            final ModifyOperation modify = operationFactory.modifyOperation();
+            ModifyRequest request = new ModifyRequest(
+                    createDnForGroup(groupName),
+                    new AttributeModification(AttributeModification.Type.ADD, new LdapAttribute(GroupMemberAttribute, createDnForUser(user)))
+            );
+            final ModifyResponse response = modify.execute(request);
+
+            if (!response.isSuccess()) {
+                throw new CesLdapException(response.getDiagnosticMessage());
+            }
+        } catch (LdapException e) {
+            throw new CesLdapException("error while adding user to group", e);
+        }
+    }
+
     private String createDnForUser(CesInternalLdapUser user) {
-        return CesInternalLdapUser.UidAttribute + "=" + user.getUid() + "," + this.baseDN;
+        return CesInternalLdapUser.UidAttribute + "=" + user.getUid() + "," + this.userBaseDN;
+    }
+
+    private String createDnForGroup(String groupName) {
+        return CesInternalLdapUser.CnAttribute + "=" + groupName + "," + this.groupBaseDN;
     }
 
     private SearchRequest createGetUserRequest(String uid) {
         String filter = String.format("(&%s%s)", uidFilter(uid), externalUsersFilter());
 
         SearchRequest request = new SearchRequest();
-        request.setBaseDn(this.baseDN);
+        request.setBaseDn(this.userBaseDN);
         request.setReturnAttributes(CesInternalLdapUser.UidAttribute, CesInternalLdapUser.CnAttribute, CesInternalLdapUser.SnAttribute, CesInternalLdapUser.GivenNameAttribute, CesInternalLdapUser.DisplayNameAttribute, CesInternalLdapUser.MailAttribute, CesInternalLdapUser.ExternalAttribute, CesInternalLdapUser.MailAttribute, CesInternalLdapUser.ExternalAttribute, CesInternalLdapUser.MemberOfAttribute);
         request.setFilter(filter);
         request.setSearchScope(SearchScope.SUBTREE);

--- a/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessor.java
+++ b/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessor.java
@@ -3,7 +3,9 @@ package de.triology.cas.oidc.beans.delegation;
 import de.triology.cas.ldap.CesInternalLdapUser;
 import de.triology.cas.ldap.UserManager;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang.ArrayUtils;
 import org.apereo.cas.authentication.Credential;
+import org.apereo.cas.authentication.adaptive.UnauthorizedAuthenticationException;
 import org.apereo.cas.authentication.principal.DelegatedAuthenticationPreProcessor;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
@@ -22,17 +24,44 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CesDelegatedAuthenticationPreProcessor implements DelegatedAuthenticationPreProcessor {
 
+    private final static String alreadyMappedAttributeName = "cesAttributesAlreadyMapped";
     private final static String groupsAttributeName = "groups";
-
-    private final List<AttributeMapping> attributeMappings;
+    private final static String externalGroupsAttributeName = "externalGroups";
 
     private final UserManager userManager;
 
+    private final List<AttributeMapping> attributeMappings;
+
+    private final String[] allowedGroups;
+
+    private final String[] adminUsernames;
+
+
     @Override
     public Principal process(Principal principal, BaseClient client, Credential credential, Service service) throws Throwable {
+        mapAttributes(principal);
 
-        // map attributes
+        if (!checkExternalAllowedGroups(principal)) {
+            throw new UnauthorizedAuthenticationException("user is not assigned to any of the allowed groups");
+        }
+
+        // attach internal groups
+        CesInternalLdapUser existingLdapUser = userManager.getUserByUid(principal.getId());
+        if (existingLdapUser != null) {
+            principal.getAttributes().put(groupsAttributeName, Arrays.asList(existingLdapUser.getGroups().toArray()));
+        }
+
+        return principal;
+    }
+
+    private void mapAttributes(Principal principal) {
         Map<String, List<Object>> principalAttributes = principal.getAttributes();
+
+        if (principalAttributes.containsKey(alreadyMappedAttributeName)) {
+            // attributes were already mapped
+            return;
+        }
+
         for (AttributeMapping mapping : attributeMappings) {
             List<Object> attributeValues = principalAttributes.get(mapping.getSource());
             if (attributeValues != null) {
@@ -40,12 +69,27 @@ public class CesDelegatedAuthenticationPreProcessor implements DelegatedAuthenti
             }
         }
 
-        // attach groups
-        CesInternalLdapUser existingLdapUser = userManager.getUserByUid(principal.getId());
-        if (existingLdapUser != null) {
-            principal.getAttributes().put(groupsAttributeName, Arrays.asList(existingLdapUser.getGroups().toArray()));
+        principalAttributes.put(alreadyMappedAttributeName, List.of(true));
+    }
+
+    private boolean checkExternalAllowedGroups(Principal principal) {
+        if (ArrayUtils.isEmpty(allowedGroups)) {
+            // no allowed groups configured -> access for all
+            return true;
         }
 
-        return principal;
+        List<Object> groups = principal.getAttributes().get(externalGroupsAttributeName);
+        if (groups == null) {
+            return false;
+        }
+
+        for (Object group : groups) {
+            if (ArrayUtils.contains(allowedGroups, group.toString())) {
+                return true;
+            }
+        }
+
+        return false;
+
     }
 }

--- a/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessor.java
+++ b/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessor.java
@@ -25,7 +25,6 @@ import java.util.Map;
 public class CesDelegatedAuthenticationPreProcessor implements DelegatedAuthenticationPreProcessor {
 
     private final static String alreadyMappedAttributeName = "cesAttributesAlreadyMapped";
-    private final static String groupsAttributeName = "groups";
     private final static String externalGroupsAttributeName = "externalGroups";
 
     private final UserManager userManager;
@@ -33,9 +32,6 @@ public class CesDelegatedAuthenticationPreProcessor implements DelegatedAuthenti
     private final List<AttributeMapping> attributeMappings;
 
     private final String[] allowedGroups;
-
-    private final String[] adminUsernames;
-
 
     @Override
     public Principal process(Principal principal, BaseClient client, Credential credential, Service service) throws Throwable {
@@ -48,7 +44,7 @@ public class CesDelegatedAuthenticationPreProcessor implements DelegatedAuthenti
         // attach internal groups
         CesInternalLdapUser existingLdapUser = userManager.getUserByUid(principal.getId());
         if (existingLdapUser != null) {
-            principal.getAttributes().put(groupsAttributeName, Arrays.asList(existingLdapUser.getGroups().toArray()));
+            PrincipalGroups.setGroupsInPrincipal(principal, Arrays.asList(existingLdapUser.getGroups().toArray()));
         }
 
         return principal;

--- a/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedClientUserProfileProvisioner.java
+++ b/app/src/main/java/de/triology/cas/oidc/beans/delegation/CesDelegatedClientUserProfileProvisioner.java
@@ -1,8 +1,10 @@
 package de.triology.cas.oidc.beans.delegation;
 
 import de.triology.cas.ldap.CesInternalLdapUser;
+import de.triology.cas.ldap.CesLdapException;
 import de.triology.cas.ldap.UserManager;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang.ArrayUtils;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.provision.DelegatedClientUserProfileProvisioner;
@@ -10,16 +12,24 @@ import org.pac4j.core.client.BaseClient;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.profile.OidcProfile;
 
+import java.util.List;
+
 /**
  * The CesDelegatedClientUserProfileProvisioner handles th provisioning of UserProfiles from the delegated authentication.
  * Currently only supports OIDC-UserProfiles ({@link OidcProfile}) and the internal CES-LDAP.
  * The CesDelegatedClientUserProfileProvisioner checks if a user for the given userProfile exists in the internal CES-LDAP.
  * If no user exists a new user will be created. If the user already exists, it will be updated with the values from the userProfile.
+ *
+ * The CesDelegatedClientUserProfileProvisioner also checks if the user belongs to the initial admin-users and assigns the admin-groups accordingly.
  */
 @RequiredArgsConstructor
 public class CesDelegatedClientUserProfileProvisioner implements DelegatedClientUserProfileProvisioner {
 
     private final UserManager userManager;
+
+    private final String[] initialAdminUsernames;
+
+    private final String[] adminGroups;
 
     @Override
     public void execute(Principal principal, UserProfile profile, BaseClient client, Credential credential) throws Throwable {
@@ -29,9 +39,24 @@ public class CesDelegatedClientUserProfileProvisioner implements DelegatedClient
         if (existingLdapUser == null) {
             // user does not exist -> create
             userManager.createUser(userFromProfile);
+
+            addAdminGroupsForUser(userFromProfile, principal);
         } else {
             // user does not exist -> update
             userManager.updateUser(userFromProfile);
+        }
+    }
+
+    private void addAdminGroupsForUser(CesInternalLdapUser user, Principal principal) throws CesLdapException {
+        List<Object> principalGroups = PrincipalGroups.getGroupsFromPrincipal(principal);
+
+        if (ArrayUtils.contains(initialAdminUsernames, user.getUid())) {
+            for (final String group : adminGroups) {
+                userManager.addUserToGroup(user, group);
+                principalGroups.add(group);
+            }
+
+            PrincipalGroups.setGroupsInPrincipal(principal, principalGroups);
         }
     }
 

--- a/app/src/main/java/de/triology/cas/oidc/beans/delegation/PrincipalGroups.java
+++ b/app/src/main/java/de/triology/cas/oidc/beans/delegation/PrincipalGroups.java
@@ -1,0 +1,26 @@
+package de.triology.cas.oidc.beans.delegation;
+
+import org.apereo.cas.authentication.principal.Principal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrincipalGroups {
+
+    private final static String groupsAttributeName = "groups";
+
+    public static List<Object> getGroupsFromPrincipal(Principal principal) {
+        List<Object> groups = principal.getAttributes().get(groupsAttributeName);
+        if (groups == null) {
+            groups = new ArrayList<>();
+        }
+
+        return groups;
+    }
+
+    public static void setGroupsInPrincipal(Principal principal, List<Object> groups) {
+        principal.getAttributes().put(groupsAttributeName, groups);
+    }
+
+
+}

--- a/app/src/main/java/de/triology/cas/oidc/config/CesOidcConfiguration.java
+++ b/app/src/main/java/de/triology/cas/oidc/config/CesOidcConfiguration.java
@@ -49,8 +49,11 @@ public class CesOidcConfiguration {
     @Value("${ces.delegation.oidc.allowedGroups:#{\"\"}}")
     private String allowedGroupsConfigString;
 
-    @Value("${ces.delegation.oidc.adminUsernames:#{\"\"}}")
-    private String adminUsernamesConfigString;
+    @Value("${ces.delegation.oidc.initialAdminUsernames:#{\"\"}}")
+    private String initialAadminUsernamesConfigString;
+
+    @Value("${ces.delegation.oidc.adminGroups:#{\"\"}}")
+    private String adminGroupsConfigString;
 
     @Bean
     @RefreshScope
@@ -73,8 +76,10 @@ public class CesOidcConfiguration {
     @RefreshScope
     public DelegatedClientUserProfileProvisioner clientUserProfileProvisioner(final CasConfigurationProperties casProperties) {
         UserManager userManager = getUserManager(casProperties);
+        String[] initialAdminUsernames = splitAndTrim(initialAadminUsernamesConfigString);
+        String[] adminGroups = splitAndTrim(adminGroupsConfigString);
 
-        return new CesDelegatedClientUserProfileProvisioner(userManager);
+        return new CesDelegatedClientUserProfileProvisioner(userManager, initialAdminUsernames, adminGroups);
     }
 
     @Bean
@@ -83,9 +88,8 @@ public class CesOidcConfiguration {
         UserManager userManager = getUserManager(casProperties);
         List<AttributeMapping> attributeMappings = AttributeMapping.fromPropertyString(attributesMappingsString);
         String[] allowedGroups = splitAndTrim(allowedGroupsConfigString);
-        String[] adminUsernames = splitAndTrim(adminUsernamesConfigString);
 
-        return new CesDelegatedAuthenticationPreProcessor(userManager, attributeMappings, allowedGroups, adminUsernames);
+        return new CesDelegatedAuthenticationPreProcessor(userManager, attributeMappings, allowedGroups);
     }
 
     private static UserManager getUserManager(CasConfigurationProperties casProperties) {

--- a/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessorTest.java
+++ b/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessorTest.java
@@ -32,7 +32,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
@@ -64,7 +64,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         UserManager userManagerMock = mock(UserManager.class);
         when(userManagerMock.getUserByUid("test_user")).thenReturn(null);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
@@ -98,7 +98,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
@@ -133,7 +133,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
@@ -166,7 +166,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
@@ -196,7 +196,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups);
 
         UnauthorizedAuthenticationException exception = assertThrows(UnauthorizedAuthenticationException.class, () -> preProcessor.process(principal, null, null, null));
 
@@ -225,7 +225,7 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups);
 
         UnauthorizedAuthenticationException exception = assertThrows(UnauthorizedAuthenticationException.class, () -> preProcessor.process(principal, null, null, null));
 

--- a/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessorTest.java
+++ b/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedAuthenticationPreProcessorTest.java
@@ -2,6 +2,7 @@ package de.triology.cas.oidc.beans.delegation;
 
 import de.triology.cas.ldap.CesInternalLdapUser;
 import de.triology.cas.ldap.UserManager;
+import org.apereo.cas.authentication.adaptive.UnauthorizedAuthenticationException;
 import org.apereo.cas.authentication.principal.Principal;
 import org.junit.Test;
 
@@ -22,7 +23,6 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         attributes.put("username", List.of("test_user"));
         when(principal.getAttributes()).thenReturn(attributes);
 
-
         List<AttributeMapping> mappings = List.of(
                 new AttributeMapping("given_name", "firstName"),
                 new AttributeMapping("family_name", "lastName")
@@ -32,11 +32,12 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         testUser.setGroups(Set.of("group1", "group2"));
         when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(mappings, userManagerMock);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
-        assertEquals(6, resultPrincipal.getAttributes().size());
+        assertEquals(7, resultPrincipal.getAttributes().size());
+        assertEquals(true, resultPrincipal.getAttributes().get("cesAttributesAlreadyMapped").getFirst());
         assertEquals("Test", resultPrincipal.getAttributes().get("given_name").getFirst());
         assertEquals("Test", resultPrincipal.getAttributes().get("firstName").getFirst());
         assertEquals("User", resultPrincipal.getAttributes().get("family_name").getFirst());
@@ -55,7 +56,6 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         attributes.put("username", List.of("test_user"));
         when(principal.getAttributes()).thenReturn(attributes);
 
-
         List<AttributeMapping> mappings = List.of(
                 new AttributeMapping("given_name", "firstName"),
                 new AttributeMapping("family_name", "lastName"),
@@ -64,16 +64,171 @@ public class CesDelegatedAuthenticationPreProcessorTest {
         UserManager userManagerMock = mock(UserManager.class);
         when(userManagerMock.getUserByUid("test_user")).thenReturn(null);
 
-        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(mappings, userManagerMock);
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
         Principal resultPrincipal = preProcessor.process(principal, null, null, null);
 
         assertNotNull(resultPrincipal);
-        assertEquals(5, resultPrincipal.getAttributes().size());
+        assertEquals(6, resultPrincipal.getAttributes().size());
+        assertEquals(true, resultPrincipal.getAttributes().get("cesAttributesAlreadyMapped").getFirst());
         assertEquals("Test", resultPrincipal.getAttributes().get("given_name").getFirst());
         assertEquals("Test", resultPrincipal.getAttributes().get("firstName").getFirst());
         assertEquals("User", resultPrincipal.getAttributes().get("family_name").getFirst());
         assertEquals("User", resultPrincipal.getAttributes().get("lastName").getFirst());
         assertEquals("test_user", resultPrincipal.getAttributes().get("username").getFirst());
         assertNull(resultPrincipal.getAttributes().get("groups"));
+    }
+
+    @Test
+    public void testProcess_alreadyMapped() throws Throwable {
+        Principal principal = mock(Principal.class);
+        when(principal.getId()).thenReturn("test_user");
+        Map<String, List<Object>> attributes = new HashMap<>();
+        attributes.put("given_name", List.of("Test"));
+        attributes.put("family_name", List.of("User"));
+        attributes.put("username", List.of("test_user"));
+        attributes.put("cesAttributesAlreadyMapped", List.of(true));
+        when(principal.getAttributes()).thenReturn(attributes);
+
+        List<AttributeMapping> mappings = List.of(
+                new AttributeMapping("given_name", "firstName"),
+                new AttributeMapping("family_name", "lastName")
+        );
+        UserManager userManagerMock = mock(UserManager.class);
+        CesInternalLdapUser testUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        testUser.setGroups(Set.of("group1", "group2"));
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
+
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, null, null);
+        Principal resultPrincipal = preProcessor.process(principal, null, null, null);
+
+        assertNotNull(resultPrincipal);
+        assertEquals(5, resultPrincipal.getAttributes().size());
+        assertEquals(true, resultPrincipal.getAttributes().get("cesAttributesAlreadyMapped").getFirst());
+        assertEquals("Test", resultPrincipal.getAttributes().get("given_name").getFirst());
+        assertEquals("User", resultPrincipal.getAttributes().get("family_name").getFirst());
+        assertEquals("test_user", resultPrincipal.getAttributes().get("username").getFirst());
+        assertArrayEquals(testUser.getGroups().toArray(), resultPrincipal.getAttributes().get("groups").toArray());
+    }
+
+    @Test
+    public void testProcessCheckAllowedGroups() throws Throwable {
+        Principal principal = mock(Principal.class);
+        when(principal.getId()).thenReturn("test_user");
+        Map<String, List<Object>> attributes = new HashMap<>();
+        attributes.put("given_name", List.of("Test"));
+        attributes.put("family_name", List.of("User"));
+        attributes.put("username", List.of("test_user"));
+        attributes.put("groups", List.of("group1", "group3"));
+        when(principal.getAttributes()).thenReturn(attributes);
+
+        String[] allowedGroups = {"group1", "group2"};
+
+        List<AttributeMapping> mappings = List.of(
+                new AttributeMapping("given_name", "firstName"),
+                new AttributeMapping("family_name", "lastName"),
+                new AttributeMapping("groups", "externalGroups")
+        );
+        UserManager userManagerMock = mock(UserManager.class);
+        CesInternalLdapUser testUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        testUser.setGroups(Set.of("group1", "group2"));
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
+
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        Principal resultPrincipal = preProcessor.process(principal, null, null, null);
+
+        assertNotNull(resultPrincipal);
+        assertEquals(8, resultPrincipal.getAttributes().size());
+        assertEquals(true, resultPrincipal.getAttributes().get("cesAttributesAlreadyMapped").getFirst());
+        assertEquals(List.of("group1", "group3"), resultPrincipal.getAttributes().get("externalGroups"));
+        assertArrayEquals(testUser.getGroups().toArray(), resultPrincipal.getAttributes().get("groups").toArray());
+    }
+
+    @Test
+    public void testProcessCheckAllowedGroups_AllAllowed() throws Throwable {
+        Principal principal = mock(Principal.class);
+        when(principal.getId()).thenReturn("test_user");
+        Map<String, List<Object>> attributes = new HashMap<>();
+        attributes.put("given_name", List.of("Test"));
+        attributes.put("family_name", List.of("User"));
+        attributes.put("username", List.of("test_user"));
+        attributes.put("groups", List.of("group44"));
+        when(principal.getAttributes()).thenReturn(attributes);
+
+        String[] allowedGroups = {};
+
+        List<AttributeMapping> mappings = List.of(
+                new AttributeMapping("given_name", "firstName"),
+                new AttributeMapping("family_name", "lastName"),
+                new AttributeMapping("groups", "externalGroups")
+        );
+        UserManager userManagerMock = mock(UserManager.class);
+        CesInternalLdapUser testUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        testUser.setGroups(Set.of("group1", "group2"));
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
+
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+        Principal resultPrincipal = preProcessor.process(principal, null, null, null);
+
+        assertNotNull(resultPrincipal);
+        assertEquals(8, resultPrincipal.getAttributes().size());
+    }
+
+    @Test
+    public void testProcessCheckAllowedGroups_NotAllowed() throws Throwable {
+        Principal principal = mock(Principal.class);
+        when(principal.getId()).thenReturn("test_user");
+        Map<String, List<Object>> attributes = new HashMap<>();
+        attributes.put("given_name", List.of("Test"));
+        attributes.put("family_name", List.of("User"));
+        attributes.put("username", List.of("test_user"));
+        attributes.put("groups", List.of("group1", "group3"));
+        when(principal.getAttributes()).thenReturn(attributes);
+
+        String[] allowedGroups = {"group2"};
+
+        List<AttributeMapping> mappings = List.of(
+                new AttributeMapping("given_name", "firstName"),
+                new AttributeMapping("family_name", "lastName"),
+                new AttributeMapping("groups", "externalGroups")
+        );
+        UserManager userManagerMock = mock(UserManager.class);
+        CesInternalLdapUser testUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        testUser.setGroups(Set.of("group1", "group2"));
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
+
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+
+        UnauthorizedAuthenticationException exception = assertThrows(UnauthorizedAuthenticationException.class, () -> preProcessor.process(principal, null, null, null));
+
+        assertEquals("user is not assigned to any of the allowed groups", exception.getMessage());
+    }
+
+    @Test
+    public void testProcessCheckAllowedGroups_NotAllowed_NoGroups() throws Throwable {
+        Principal principal = mock(Principal.class);
+        when(principal.getId()).thenReturn("test_user");
+        Map<String, List<Object>> attributes = new HashMap<>();
+        attributes.put("given_name", List.of("Test"));
+        attributes.put("family_name", List.of("User"));
+        attributes.put("username", List.of("test_user"));
+        when(principal.getAttributes()).thenReturn(attributes);
+
+        String[] allowedGroups = {"group2"};
+
+        List<AttributeMapping> mappings = List.of(
+                new AttributeMapping("given_name", "firstName"),
+                new AttributeMapping("family_name", "lastName"),
+                new AttributeMapping("groups", "externalGroups")
+        );
+        UserManager userManagerMock = mock(UserManager.class);
+        CesInternalLdapUser testUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        testUser.setGroups(Set.of("group1", "group2"));
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(testUser);
+
+        CesDelegatedAuthenticationPreProcessor preProcessor = new CesDelegatedAuthenticationPreProcessor(userManagerMock, mappings, allowedGroups, null);
+
+        UnauthorizedAuthenticationException exception = assertThrows(UnauthorizedAuthenticationException.class, () -> preProcessor.process(principal, null, null, null));
+
+        assertEquals("user is not assigned to any of the allowed groups", exception.getMessage());
     }
 }

--- a/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedClientUserProfileProvisionerTest.java
+++ b/app/src/test/java/de/triology/cas/oidc/beans/delegation/CesDelegatedClientUserProfileProvisionerTest.java
@@ -3,6 +3,7 @@ package de.triology.cas.oidc.beans.delegation;
 import de.triology.cas.ldap.CesInternalLdapUser;
 import de.triology.cas.ldap.CesLdapException;
 import de.triology.cas.ldap.UserManager;
+import org.apereo.cas.authentication.principal.Principal;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pac4j.core.profile.CommonProfile;
@@ -10,6 +11,9 @@ import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.OidcProfileDefinition;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,7 +37,7 @@ public class CesDelegatedClientUserProfileProvisionerTest {
         CesInternalLdapUser expectedCesUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
         Mockito.doNothing().when(userManagerMock).updateUser(expectedCesUser);
 
-        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock);
+        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock, null, null);
         provisioner.execute(null, profile, null, null);
 
         verify(userManagerMock, times(1)).updateUser(expectedCesUser);
@@ -54,10 +58,69 @@ public class CesDelegatedClientUserProfileProvisionerTest {
         CesInternalLdapUser expectedCesUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
         Mockito.doNothing().when(userManagerMock).createUser(expectedCesUser);
 
-        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock);
-        provisioner.execute(null, profile, null, null);
+        Principal principal = mock(Principal.class);
+        when(principal.getAttributes()).thenReturn(new HashMap<>());
+
+        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock, null, null);
+        provisioner.execute(principal, profile, null, null);
 
         verify(userManagerMock, times(1)).createUser(expectedCesUser);
+    }
+
+    @Test
+    public void testExecute_withNewUserAddAdminGroups() throws Throwable {
+        OidcProfile profile = new OidcProfile();
+        profile.addAttribute(OidcProfileDefinition.PREFERRED_USERNAME, "test_user");
+        profile.addAttribute(OidcProfileDefinition.GIVEN_NAME, "Test");
+        profile.addAttribute(OidcProfileDefinition.FAMILY_NAME, "User");
+        profile.addAttribute(OidcProfileDefinition.NAME, "Test User");
+        profile.addAttribute(OidcProfileDefinition.EMAIL, "test@user.de");
+
+        UserManager userManagerMock = mock(UserManager.class);
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(null);
+
+        CesInternalLdapUser expectedCesUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        Mockito.doNothing().when(userManagerMock).createUser(expectedCesUser);
+        Mockito.doNothing().when(userManagerMock).addUserToGroup(expectedCesUser, "group1");
+        Mockito.doNothing().when(userManagerMock).addUserToGroup(expectedCesUser, "group2");
+
+        Principal principal = mock(Principal.class);
+        when(principal.getAttributes()).thenReturn(new HashMap<>());
+
+        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock, new String[]{"test_user"}, new String[]{"group1", "group2"});
+        provisioner.execute(principal, profile, null, null);
+
+        verify(userManagerMock, times(1)).createUser(expectedCesUser);
+        verify(userManagerMock, times(1)).addUserToGroup(expectedCesUser, "group1");
+        verify(userManagerMock, times(1)).addUserToGroup(expectedCesUser, "group2");
+    }
+
+    @Test
+    public void testExecute_withNewUserDoNotAddAdminGroups() throws Throwable {
+        OidcProfile profile = new OidcProfile();
+        profile.addAttribute(OidcProfileDefinition.PREFERRED_USERNAME, "test_user");
+        profile.addAttribute(OidcProfileDefinition.GIVEN_NAME, "Test");
+        profile.addAttribute(OidcProfileDefinition.FAMILY_NAME, "User");
+        profile.addAttribute(OidcProfileDefinition.NAME, "Test User");
+        profile.addAttribute(OidcProfileDefinition.EMAIL, "test@user.de");
+
+        UserManager userManagerMock = mock(UserManager.class);
+        when(userManagerMock.getUserByUid("test_user")).thenReturn(null);
+
+        CesInternalLdapUser expectedCesUser = new CesInternalLdapUser("test_user", "Test", "User", "Test User", "test@user.de", true);
+        Mockito.doNothing().when(userManagerMock).createUser(expectedCesUser);
+        Mockito.doNothing().when(userManagerMock).addUserToGroup(expectedCesUser, "group1");
+        Mockito.doNothing().when(userManagerMock).addUserToGroup(expectedCesUser, "group2");
+
+        Principal principal = mock(Principal.class);
+        when(principal.getAttributes()).thenReturn(new HashMap<>());
+
+        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock, new String[]{"super_admin"}, new String[]{"group1", "group2"});
+        provisioner.execute(principal, profile, null, null);
+
+        verify(userManagerMock, times(1)).createUser(expectedCesUser);
+        verify(userManagerMock, times(0)).addUserToGroup(expectedCesUser, "group1");
+        verify(userManagerMock, times(0)).addUserToGroup(expectedCesUser, "group2");
     }
 
     @Test
@@ -66,7 +129,7 @@ public class CesDelegatedClientUserProfileProvisionerTest {
 
         UserManager userManagerMock = mock(UserManager.class);
 
-        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock);
+        CesDelegatedClientUserProfileProvisioner provisioner = new CesDelegatedClientUserProfileProvisioner(userManagerMock, null, null);
 
         RuntimeException e = assertThrows(RuntimeException.class, () -> provisioner.execute(null, profile, null, null));
         assertEquals("Unsupported profile type: CommonProfile", e.getMessage());

--- a/docs/development/example_oidc_configuration_de.md
+++ b/docs/development/example_oidc_configuration_de.md
@@ -1,0 +1,23 @@
+# Beispiel-Konfiguration für delegierte Authentifizierung mit OIDC
+
+Dies ist eine Beispiel-Konfiguration für die delegierte Authentifizierung im CAS über OIDC.
+Diese Werte können im CES-MN direkt in die `cas-config`-ConfigMap eingetragen werden.
+Für Classic-CES müssen sie entsprechend im ETCD eingetragen werden.
+
+```yaml
+oidc:
+  enabled: "true"
+  discovery_uri: "http://192.168.56.1:8080/auth/realms/Cloudogu/.well-known/openid-configuration"
+  client_id: "cesCasClient"
+  client_secret: "MySecretSecret"
+  #redirect_uri: "https://platform.cloudogu.com/de/"                                                                                                                                                             
+  display_name: "Cloudogu-Platform"
+  optional: "true"
+  scopes: "openid email profile GroupScope"
+  principal_attribute: "preferred_username"
+  attribute_mapping: "email:mail,family_name:surname,given_name:givenName,preferred_username:username,name:displayName,groups:externalGroups"
+  allowed_groups: "Gruppe2, Gruppe3"
+  admin_usernames: "user1, testAdmin"                      
+```
+
+> **Achtung:** Im Produktions-Betrieb sollte der Config-Wert für `client_secret` im Kubernetes-Secret der CAS-Config eingetragen werden. 

--- a/docs/development/example_oidc_configuration_de.md
+++ b/docs/development/example_oidc_configuration_de.md
@@ -17,7 +17,7 @@ oidc:
   principal_attribute: "preferred_username"
   attribute_mapping: "email:mail,family_name:surname,given_name:givenName,preferred_username:username,name:displayName,groups:externalGroups"
   allowed_groups: "Gruppe2, Gruppe3"
-  admin_usernames: "user1, testAdmin"                      
+  initial_admin_usernames: "user1, testAdmin"                      
 ```
 
 > **Achtung:** Im Produktions-Betrieb sollte der Config-Wert für `client_secret` im Kubernetes-Secret der CAS-Config eingetragen werden. 

--- a/docs/development/example_oidc_configuration_en.md
+++ b/docs/development/example_oidc_configuration_en.md
@@ -1,0 +1,23 @@
+# Example configuration for delegated authentication with OIDC
+
+This is an example configuration for delegated authentication in CAS via OIDC.
+These values can be entered directly in the `cas-config`-ConfigMap in CES-MN.
+For Classic-CES, they must be entered accordingly in the ETCD.
+
+```yaml
+oidc:
+  enabled: "true"
+  discovery_uri: "http://192.168.56.1:8080/auth/realms/Cloudogu/.well-known/openid-configuration"
+  client_id: "cesCasClient"
+  client_secret: "MySecretSecret"
+  #redirect_uri: "https://platform.cloudogu.com/de/"                                                                                                                                                             
+  display_name: "Cloudogu-Platform"
+  optional: "true"
+  scopes: "openid email profile GroupScope"
+  principal_attribute: "preferred_username"
+  attribute_mapping: "email:mail,family_name:surname,given_name:givenName,preferred_username:username,name:displayName,groups:externalGroups"
+  allowed_groups: "Gruppe2, Gruppe3"
+  admin_usernames: "user1, testAdmin"                 
+```
+
+**Attention:** In production mode, the config value for `client_secret` should be entered in the Kubernetes-Secret of the CAS-Config.

--- a/docs/development/example_oidc_configuration_en.md
+++ b/docs/development/example_oidc_configuration_en.md
@@ -17,7 +17,7 @@ oidc:
   principal_attribute: "preferred_username"
   attribute_mapping: "email:mail,family_name:surname,given_name:givenName,preferred_username:username,name:displayName,groups:externalGroups"
   allowed_groups: "Gruppe2, Gruppe3"
-  admin_usernames: "user1, testAdmin"                 
+  initial_admin_usernames: "user1, testAdmin"                 
 ```
 
 **Attention:** In production mode, the config value for `client_secret` should be entered in the Kubernetes-Secret of the CAS-Config.

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,9 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Bei der Anmeldung über eine delegierte Authentifizierung können jetzt `allowed_groups` und `initial_admin_usernames` konfiguriert werden.
+  - `allowed_groups`: Gibt eine Liste von OIDC-Gruppen an, die sich mit delegierter Authentifizierung anmelden dürfen. Die Gruppen werden durch Komma getrennt. Eine leere Liste erlaubt den Zugang für alle.
+  - `initial_admin_usernames`: Gibt eine Liste von Benutzernamen an, die der CES-Admin-Gruppe bei der ersten Anmeldung zugewiesen werden.
 
 ## Release 7.0.8-9
 - Es wurde ein Problem behoben, bei dem das Dogu unter hoher Systemlast nicht mehr startet.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,9 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- When logging in via delegated authentication, `allowed_groups` and `initial_admin_usernames` can now be configured.
+  - `allowed_groups`: Specifies a list of OIDC groups that are allowed to log on with delegated authentication. The groups are separated by commas. An empty list allows access for all.
+  - `initial_admin_usernames`: Specifies a list of usernames that are assigned to the CES admin group at the first login.
 
 ## Release 7.0.8-9
 - Fixed a problem where the Dogu does not start under high system load.

--- a/docs/operations/Configure_OIDC_Provider_de.md
+++ b/docs/operations/Configure_OIDC_Provider_de.md
@@ -63,3 +63,13 @@ Eine solche Registrierung besteht grundsätzlich aus einer Client-ID und einem C
 * Konfiguration-Schlüssel-Pfad: `<cas_path>/oidc/principal_attribute`
 * Inhalt: Gibt ein Attribut an, das als Haupt-ID innerhalb des CES verwendet werden soll. CAS verwendet die vom OIDC-Anbieter bereitgestellte ID, wenn diese Eigenschaft leer ist.
 * Datentyp: Name eines OIDC attribute
+
+#### oidc/allowed_groups
+* Pfad des Konfigurationsschlüssels: `<cas_path>/oidc/allowed_groups`
+* Inhalt: Gibt eine Liste von OIDC-Gruppen an, die sich mit delegierter Authentifizierung anmelden dürfen. Die Gruppen werden durch Komma getrennt. Eine leere Liste erlaubt den Zugang für alle.
+* Datentyp: String nach Format: `Gruppe1, Gruppe2`.
+
+#### oidc/initial_admin_usernames
+* Pfad des Konfigurationsschlüssels: `<cas_path>/oidc/initial_admin_usernames`
+* Inhalt: Gibt eine Liste von Benutzernamen an, die der CES-Admin-Gruppe bei der ersten Anmeldung zugewiesen werden.
+* Datentyp: String nach dem Format: `Benutzer1, Benutzer2`.

--- a/docs/operations/Configure_OIDC_Provider_en.md
+++ b/docs/operations/Configure_OIDC_Provider_en.md
@@ -63,3 +63,13 @@ Such registration basically consists of a client ID and a client secret.
 * Configuration key path: `<cas_path>/oidc/principal_attribute`
 * Contents: Specifies an attribute that should be used as principal id inside the CES. CAS uses the ID provided by the OIDC provider when this property is empty.
 * Data type: Name of OIDC attribute
+
+#### oidc/allowed_groups
+* Configuration key path: `<cas_path>/oidc/allowed_groups`
+* Inhalt: Specifies a list of OIDC groups that are allowed to log in using delegated authentication. The groups are seperated by comma. An empty list allows access for everyone.
+* Datentyp: String according to format: `Group1, Group2`.
+
+#### oidc/initial_admin_usernames
+* Configuration key path: `<cas_path>/oidc/initial_admin_usernames`
+* Inhalt: Specifies a list of usernames that will be assigned to the CES admin-group, when they first log in.
+* Datentyp: String according to format: `User1, User2`.

--- a/dogu.json
+++ b/dogu.json
@@ -383,8 +383,8 @@
       "Optional": true
     },
     {
-      "Name": "oidc/admin_usernames",
-      "Description": "Specifies a list of usernames that will be assigned to the CES admin-group",
+      "Name": "oidc/initial_admin_usernames",
+      "Description": "Specifies a list of usernames that will be assigned to the CES admin-group, when they first login.",
       "Optional": true
     }
   ],

--- a/dogu.json
+++ b/dogu.json
@@ -369,12 +369,22 @@
     },
     {
       "Name": "oidc/attribute_mapping",
-      "Description": "The attributes provided by OIDC do not exactly match the attributes required by the CAS. It is necessary to transform the OIDC attributes into attributes accepted by the cas. Therefore, this entry should contain rules to transform an attribute provided by the OIDC provider into an attribute required by CAS. The rules should be provided in the following format: 'email:mail,family_name:surname'. With the given example the OIDC attribute 'email' and 'family_name' are transformed into 'mail' and 'surname' respectively. The CAS requires the following attributes to function properly: 'mail,surname,givenName,username,displayName'.",
+      "Description": "The attributes provided by OIDC do not exactly match the attributes required by the CAS. It is necessary to transform the OIDC attributes into attributes accepted by the cas. Therefore, this entry should contain rules to transform an attribute provided by the OIDC provider into an attribute required by CAS. The rules should be provided in the following format: 'email:mail,family_name:surname'. With the given example the OIDC attribute 'email' and 'family_name' are transformed into 'mail' and 'surname' respectively. The CAS requires the following attributes to function properly: 'mail,surname,givenName,username,displayName,externalGroups'.",
       "Optional": true
     },
     {
       "Name": "oidc/principal_attribute",
       "Description": "Specifies an attribute that should be used as principal id inside the CES. CAS uses the ID provided by the OIDC provider when this property is empty.",
+      "Optional": true
+    },
+    {
+      "Name": "oidc/allowed_groups",
+      "Description": "Specifies a list of OIDC groups that are allowed to login using delegated authentication. The groups are seperated by comma. An empty list allows access for everyone.",
+      "Optional": true
+    },
+    {
+      "Name": "oidc/admin_usernames",
+      "Description": "Specifies a list of usernames that will be assigned to the CES admin-group",
       "Optional": true
     }
   ],

--- a/resources/etc/cas/config/cas.properties.tpl
+++ b/resources/etc/cas/config/cas.properties.tpl
@@ -261,6 +261,13 @@ ces.delegation.oidc.redirect-uri={{ .Config.GetOrDefault "oidc/redirect_uri" "" 
 
 ### attribute mapping
 ces.delegation.oidc.attributeMapping={{ .Config.Get "oidc/attribute_mapping"}}
+
+### allowed groups - group-names that are allowed to login
+ces.delegation.oidc.allowedGroups={{ .Config.GetOrDefault "oidc/allowed_groups" ""}}
+
+### admin usernames - usernames that will be assigned the admin-group
+ces.delegation.oidc.adminUsernames={{ .Config.GetOrDefault "oidc/admin_usernames" ""}}
+
 {{ end }}
 ########################################################################################################################
 

--- a/resources/etc/cas/config/cas.properties.tpl
+++ b/resources/etc/cas/config/cas.properties.tpl
@@ -266,7 +266,8 @@ ces.delegation.oidc.attributeMapping={{ .Config.Get "oidc/attribute_mapping"}}
 ces.delegation.oidc.allowedGroups={{ .Config.GetOrDefault "oidc/allowed_groups" ""}}
 
 ### admin usernames - usernames that will be assigned the admin-group
-ces.delegation.oidc.adminUsernames={{ .Config.GetOrDefault "oidc/admin_usernames" ""}}
+ces.delegation.oidc.initialAdminUsernames={{ .Config.GetOrDefault "oidc/initial_admin_usernames" ""}}
+ces.delegation.oidc.adminGroups={{ .GlobalConfig.GetOrDefault "admin_group" "cesAdmin"}},{{ .GlobalConfig.GetOrDefault "manager_group" "cesManager"}}
 
 {{ end }}
 ########################################################################################################################

--- a/resources/test-password-logging.sh
+++ b/resources/test-password-logging.sh
@@ -54,11 +54,11 @@ echo "Testing service ticket creation with new user"
 # A service ticket is a type of authentication that is password based
 # this valid service ticket will appear in the cas logs as well
 curl -f -L "https://${CES_URL}/cas/v1/tickets" --data "username=${PWD_LOGGING_USER}&password=${PWD_LOGGING_PASSWORD}" --insecure \
- -H 'Content-type: Application/x-www-form-urlencoded' --http1.0 -X POST > serviceTicket
+ -H 'Content-type: application/x-www-form-urlencoded' --http1.0 -X POST > serviceTicket
 echo "creating ticketGrantingTicket"
 ticketGrantingTicket=$(grep -o TGT-.*cas serviceTicket)
-curl -L -v "https://${CES_URL}/cas/v1/tickets/${ticketGrantingTicket}?service=https%3A%2F%2F${CES_URL}%2Fusermgt" --insecure \
- -H 'Content-type: Application/x-www-form-urlencoded' --http1.0 -X POST --data "username=${PWD_LOGGING_USER}&password=${PWD_LOGGING_PASSWORD}" > serviceTicket
+curl -f -L -v "https://${CES_URL}/cas/v1/tickets/${ticketGrantingTicket}?service=https%3A%2F%2F${CES_URL}%2Fusermgt" --insecure \
+ -H 'Content-type: application/x-www-form-urlencoded' --http1.0 -X POST --data "username=${PWD_LOGGING_USER}&password=${PWD_LOGGING_PASSWORD}" > serviceTicket
 validTicket=$(cat serviceTicket)
 curl -s -L -X GET --insecure "https://${CES_URL}/cas/p3/serviceValidate?service=https://${CES_URL}usermgt&ticket=${validTicket}" --http1.0 > serviceTicket
 


### PR DESCRIPTION
When logging in via delegated authentication, `allowed_groups` and `initial_admin_usernames` can now be configured.
  - `allowed_groups`: Specifies a list of OIDC groups that are allowed to log on with delegated authentication. The groups are separated by commas. An empty list allows access for all.
  - `initial_admin_usernames`: Specifies a list of usernames that are assigned to the CES admin group at the first login.

closes #244 