### PR TITLE
#246 accept empty config value for `oidc/enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#246] Update base image to Alpine 3.21.0 and Java to 21.0.5-p11
+
 ### Fixed
 - [#246] Fix a restart loop if the config key `oidc/enabled` was not set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix a restart loop if the config key `oidc/enabled` was not set.
 
 ## [v7.0.8-9] - 2024-12-20
 ### Added
@@ -13,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix start under high system load [#240]
-- Fix a restart loop if the config key `oidc/enabled` was not set.
 
 ## [v7.0.8-8] - 2024-12-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix start under high system load [#240]
+- Fix a restart loop if the config key `oidc/enabled` was not set.
 
 ## [v7.0.8-8] - 2024-12-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix a restart loop if the config key `oidc/enabled` was not set.
+- [#246] Fix a restart loop if the config key `oidc/enabled` was not set.
 
 ## [v7.0.8-9] - 2024-12-20
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apk update && apk add wget && wget -O  "apache-tomcat-${TOMCAT_VERSION}.tar.
 
 
 # registry.cloudogu.com/official/cas
-FROM registry.cloudogu.com/official/java:21.0.4-4
+FROM registry.cloudogu.com/official/java:21.0.5-1
 
 LABEL NAME="official/cas" \
       VERSION="7.0.8-9" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ String doguName = "cas"
 String branch = "${env.BRANCH_NAME}"
 
 EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")
-Trivy trivy = new Trivy(this)
 
 Git git = new Git(this, "cesmarvin")
 git.committerName = 'cesmarvin'
@@ -39,8 +38,8 @@ parallel(
                         }
 
                         stage('Unit Test') {
-                            gradlew 'test'
-                            junit allowEmptyResults: true, testResults: '**/build/test-results/test/TEST-*.xml'
+                             gradlew 'test'
+                             junit allowEmptyResults: true, testResults: '**/build/test-results/test/TEST-*.xml'
                         }
                     }
 
@@ -92,7 +91,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])
@@ -174,9 +173,12 @@ parallel(
                         }
 
                         stage('Trivy scan') {
-                            trivy.scanDogu("/dogu", TrivyScanFormat.HTML, params.TrivyScanLevels, params.TrivyStrategy)
-                            trivy.scanDogu("/dogu", TrivyScanFormat.JSON,  params.TrivyScanLevels, params.TrivyStrategy)
-                            trivy.scanDogu("/dogu", TrivyScanFormat.PLAIN, params.TrivyScanLevels, params.TrivyStrategy)
+                            ecoSystem.copyDoguImageToJenkinsWorker("/dogu")
+                            Trivy trivy = new Trivy(this)
+                            trivy.scanDogu(".", params.TrivySeverityLevels, params.TrivyStrategy)
+                            trivy.saveFormattedTrivyReport(TrivyScanFormat.TABLE)
+                            trivy.saveFormattedTrivyReport(TrivyScanFormat.JSON)
+                            trivy.saveFormattedTrivyReport(TrivyScanFormat.HTML)
                         }
 
                         stage('Verify') {
@@ -195,15 +197,15 @@ parallel(
                             ecoSystem.vagrant.ssh "sudo docker cp /dogu/integrationTests/services/ cas:/etc/cas/services/production/"
                             ecoSystem.vagrant.sshOut "sudo docker exec cas ls /etc/cas/services/production"
 
-                           ecoSystem.runCypressIntegrationTests([
+                            ecoSystem.runCypressIntegrationTests([
                                     cypressImage     : "cypress/included:13.13.2",
                                     enableVideo      : params.EnableVideoRecording,
-                                   enableScreenshots: params.EnableScreenshotRecording])
-                           // run special non-encrypted password test
-                           echo "Run unencrypted password test script"
-                           ecoSystem.vagrant.sshOut 'chmod +x /dogu/resources/test-password-logging.sh'
-                           def testreport = ecoSystem.vagrant.sshOut "sudo /dogu/resources/test-password-logging.sh ${ecoSystem.externalIP}"
-                           echo "${testreport}"
+                                    enableScreenshots: params.EnableScreenshotRecording])
+                            // run special non-encrypted password test
+                            echo "Run unencrypted password test script"
+                            ecoSystem.vagrant.sshOut 'chmod +x /dogu/resources/test-password-logging.sh'
+                            def testreport = ecoSystem.vagrant.sshOut "sudo /dogu/resources/test-password-logging.sh ${ecoSystem.externalIP}"
+                            echo "${testreport}"
                         }
 
                         if (params.TestDoguUpgrade != null && params.TestDoguUpgrade) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH, TrivySeverityLevel.MEDIUM, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH, TrivySeverityLevel.MEDIUM, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@2.4.0', 'github.com/cloudogu/dogu-build-lib@v2.4.0'])
+@Library(['github.com/cloudogu/ces-build-lib@4.0.1', 'github.com/cloudogu/dogu-build-lib@v3.0.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivyScanLevels', choices: [TrivyScanLevel.CRITICAL, TrivyScanLevel.HIGH, TrivyScanLevel.MEDIUM, TrivyScanLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH, TrivySeverityLevel.MEDIUM, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ String doguName = "cas"
 String branch = "${env.BRANCH_NAME}"
 
 EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")
-Trivy trivy = new Trivy(this)
+Trivy trivy = new Trivy(this, ecoSystem)
 
 Git git = new Git(this, "cesmarvin")
 git.committerName = 'cesmarvin'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH, TrivySeverityLevel.MEDIUM, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivyScanLevels', choices: [TrivyScanLevel.CRITICAL, TrivyScanLevel.HIGH, TrivyScanLevel.MEDIUM, TrivyScanLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ String doguName = "cas"
 String branch = "${env.BRANCH_NAME}"
 
 EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")
-Trivy trivy = new Trivy(this, ecoSystem)
+Trivy trivy = new Trivy(this)
 
 Git git = new Git(this, "cesmarvin")
 git.committerName = 'cesmarvin'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@4.0.1', 'github.com/cloudogu/dogu-build-lib@v3.0.0'])
+@Library(['github.com/cloudogu/ces-build-lib@2.4.0', 'github.com/cloudogu/dogu-build-lib@v2.4.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ String doguName = "cas"
 String branch = "${env.BRANCH_NAME}"
 
 EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")
+Trivy trivy = new Trivy(this)
 
 Git git = new Git(this, "cesmarvin")
 git.committerName = 'cesmarvin'
@@ -38,8 +39,8 @@ parallel(
                         }
 
                         stage('Unit Test') {
-                             gradlew 'test'
-                             junit allowEmptyResults: true, testResults: '**/build/test-results/test/TEST-*.xml'
+                            gradlew 'test'
+                            junit allowEmptyResults: true, testResults: '**/build/test-results/test/TEST-*.xml'
                         }
                     }
 
@@ -91,7 +92,7 @@ parallel(
                                     string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to record video of the integration tests.', name: 'EnableVideoRecording'),
                                     booleanParam(defaultValue: true, description: 'Enables cypress to take screenshots of failing integration tests.', name: 'EnableScreenshotRecording'),
-                                    choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                                    choice(name: 'TrivyScanLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
                                     choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.')
                             ])
                     ])
@@ -173,12 +174,9 @@ parallel(
                         }
 
                         stage('Trivy scan') {
-                            ecoSystem.copyDoguImageToJenkinsWorker("/dogu")
-                            Trivy trivy = new Trivy(this)
-                            trivy.scanDogu(".", params.TrivySeverityLevels, params.TrivyStrategy)
-                            trivy.saveFormattedTrivyReport(TrivyScanFormat.TABLE)
-                            trivy.saveFormattedTrivyReport(TrivyScanFormat.JSON)
-                            trivy.saveFormattedTrivyReport(TrivyScanFormat.HTML)
+                            trivy.scanDogu("/dogu", TrivyScanFormat.HTML, params.TrivyScanLevels, params.TrivyStrategy)
+                            trivy.scanDogu("/dogu", TrivyScanFormat.JSON,  params.TrivyScanLevels, params.TrivyStrategy)
+                            trivy.scanDogu("/dogu", TrivyScanFormat.PLAIN, params.TrivyScanLevels, params.TrivyStrategy)
                         }
 
                         stage('Verify') {
@@ -197,15 +195,15 @@ parallel(
                             ecoSystem.vagrant.ssh "sudo docker cp /dogu/integrationTests/services/ cas:/etc/cas/services/production/"
                             ecoSystem.vagrant.sshOut "sudo docker exec cas ls /etc/cas/services/production"
 
-                            ecoSystem.runCypressIntegrationTests([
+                           ecoSystem.runCypressIntegrationTests([
                                     cypressImage     : "cypress/included:13.13.2",
                                     enableVideo      : params.EnableVideoRecording,
-                                    enableScreenshots: params.EnableScreenshotRecording])
-                            // run special non-encrypted password test
-                            echo "Run unencrypted password test script"
-                            ecoSystem.vagrant.sshOut 'chmod +x /dogu/resources/test-password-logging.sh'
-                            def testreport = ecoSystem.vagrant.sshOut "sudo /dogu/resources/test-password-logging.sh ${ecoSystem.externalIP}"
-                            echo "${testreport}"
+                                   enableScreenshots: params.EnableScreenshotRecording])
+                           // run special non-encrypted password test
+                           echo "Run unencrypted password test script"
+                           ecoSystem.vagrant.sshOut 'chmod +x /dogu/resources/test-password-logging.sh'
+                           def testreport = ecoSystem.vagrant.sshOut "sudo /dogu/resources/test-password-logging.sh ${ecoSystem.externalIP}"
+                           echo "${testreport}"
                         }
 
                         if (params.TestDoguUpgrade != null && params.TestDoguUpgrade) {

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,7 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Es wurde der CAS-Start robuster bei ungesetzten Konfigurationsschlüssel gestaltet.
 
 ## Release 7.0.8-9
 - Es wurde ein Problem behoben, bei dem das Dogu unter hoher Systemlast nicht mehr startet.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,7 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Makes the CAS start-up more robust against unset configuration keys.
 
 ## Release 7.0.8-9
 - Fixed a problem where the Dogu does not start under high system load.

--- a/resources/etc/cas/config/cas.properties.tpl
+++ b/resources/etc/cas/config/cas.properties.tpl
@@ -223,7 +223,7 @@ cas.ticket.tgt.core.only-track-most-recent-session=false
 # Configuration guide:
 # Properties: https://apereo.github.io/cas/7.0.x/integration/Delegate-Authentication-Generic-OpenID-Connect.html
 # ----------------------------------------------------------------------------------------------------------------------
-{{ if ne (.Config.Get "oidc/enabled") "false"}}
+{{ if eq (.Config.Get "oidc/enabled") "true"}}
 cas.authn.pac4j.oidc[0].generic.enabled=true
 
 ### path to the discovery url of the provider


### PR DESCRIPTION
This PR resolves #246 

The previous templating relied on this key to be explicitly set, either to false or to true. This is not always the case if the key is untouched by the user. This should map to false.

This commit inverts the logic as trade-in for a slightly more light-weight statement compared to
`{{ if eq (.Config.GetOrDefault "false" "oidc/enabled") "true"}}...`