### PR TITLE
Fix/cas pgturlv7.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fix: Injects the missing `pgtUrl` attribute into the model in `cas3ServiceSuccessView` to properly render the `<cas:proxy>` element in the CAS 3.0 service ticket response.
 
 ## [v7.1.6-1] - 2025-04-30
 ### Changed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,10 +137,13 @@ dependencies {
     implementation "org.apereo.cas:cas-server-core-services-authentication"
     implementation "org.apereo.cas:cas-server-core-services-registry"
     implementation "org.apereo.cas:cas-server-core-util"
+    implementation "org.apereo.cas:cas-server-core-web"
     implementation "org.apereo.cas:cas-server-core-web-api"
     implementation "org.apereo.cas:cas-server-core-webflow"
     implementation "org.apereo.cas:cas-server-core-webflow-api"
-
+    implementation "org.apereo.cas:cas-server-support-validation-core"
+    implementation "org.apereo.cas:cas-server-core-validation-api"
+    
     implementation "org.apereo.cas:cas-server-support-ldap"
     implementation "org.apereo.cas:cas-server-support-ldap-core"
 

--- a/app/src/main/java/de/triology/cas/pm/CesLdapPasswordManagementService.java
+++ b/app/src/main/java/de/triology/cas/pm/CesLdapPasswordManagementService.java
@@ -12,7 +12,6 @@ import org.apereo.cas.util.crypto.CipherExecutor;
 import org.ldaptive.ConnectionFactory;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;

--- a/app/src/main/java/de/triology/cas/pm/PmConfiguration.java
+++ b/app/src/main/java/de/triology/cas/pm/PmConfiguration.java
@@ -1,7 +1,6 @@
 package de.triology.cas.pm;
 
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
-import org.apereo.cas.authentication.MultifactorAuthenticationProvider;
 import org.apereo.cas.authentication.MultifactorAuthenticationProviderSelector;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;

--- a/app/src/main/java/de/triology/cas/services/CasCustomTemplateManagerConfiguration.java
+++ b/app/src/main/java/de/triology/cas/services/CasCustomTemplateManagerConfiguration.java
@@ -1,10 +1,18 @@
 package de.triology.cas.services;
 
+import lombok.val;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
+import org.apereo.cas.authentication.ProtocolAttributeEncoder;
+import org.apereo.cas.authentication.attribute.AttributeDefinitionStore;
+import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.services.ServiceRegistryProperties;
 import org.apereo.cas.services.util.RegisteredServiceJsonSerializer;
+import org.apereo.cas.validation.AuthenticationAttributeReleasePolicy;
+import org.apereo.cas.validation.CasProtocolAttributesRenderer;
+import org.apereo.cas.validation.CasProtocolViewFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationEventPublisher;
@@ -12,12 +20,19 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.apereo.cas.validation.Assertion;
 
 import java.io.File;
 
 import org.apereo.cas.services.*;
 import java.nio.file.Path;
 import java.util.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.servlet.View;
+
 
 @Configuration("CasCustomTemplateManagerConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
@@ -25,7 +40,74 @@ import java.util.*;
 @Slf4j
 public class CasCustomTemplateManagerConfiguration {
 
+    @Bean(name = "cas3ServiceSuccessView")
+    @RefreshScope
+    public View cas3ServiceSuccessView(
+        @Qualifier(AttributeDefinitionStore.BEAN_NAME) AttributeDefinitionStore attributeDefinitionStore,
+        @Qualifier(AuthenticationAttributeReleasePolicy.BEAN_NAME) AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
+        @Qualifier("casAttributeEncoder") ProtocolAttributeEncoder protocolAttributeEncoder,
+        @Qualifier(ServicesManager.BEAN_NAME) ServicesManager servicesManager,
+        @Qualifier(AuthenticationServiceSelectionPlan.BEAN_NAME) AuthenticationServiceSelectionPlan authenticationServiceSelectionPlan,
+        @Qualifier("cas3ProtocolAttributesRenderer") CasProtocolAttributesRenderer cas3ProtocolAttributesRenderer,
+        @Qualifier("cas3SuccessView") View mustacheView
+    ) {
+        return new View() {
+            @Override
+            public String getContentType() {
+                return mustacheView.getContentType();
+            }
 
+            @Override
+            public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+                if (model instanceof Map m && !m.containsKey("_proxiesInjected")) {
+                    Object assertionObj = m.get("assertion");
+                    if (assertionObj instanceof Assertion assertion) {
+                        LOGGER.info("Assertion found: {}", assertion.getClass().getSimpleName());
+                        LOGGER.info("Primary authentication principal: {}", assertion.getPrimaryAuthentication().getPrincipal().getId());
+
+                        // Add `principal` for mustache template
+                        m.put("principal", assertion.getPrimaryAuthentication().getPrincipal());
+
+                        List<String> proxies = new ArrayList<>();
+                        for (val auth : assertion.getChainedAuthentications().stream().skip(1).toList()) {
+                            LOGGER.info("Checking proxy authentication: {}", auth);
+
+                            Object attr = auth.getAttributes().get("pgtUrl");
+                            if (attr instanceof String s) {
+                                LOGGER.info("Found proxyCallbackUrl (String): {}", s);
+                                proxies.add(s);
+                            } else if (attr instanceof List<?> list && !list.isEmpty()) {
+                                LOGGER.info("Found proxyCallbackUrl (List): {}", list.get(0));
+                                proxies.add(String.valueOf(list.get(0)));
+                            } else {
+                                String proxyId = auth.getPrincipal().getId();
+                                LOGGER.info("No proxyCallbackUrl found, using principal instead: {}", proxyId);
+                                proxies.add(proxyId);
+                            }
+                        }
+                        
+                        LOGGER.info("Injecting proxies into model: {}", proxies);
+                        m.put("proxies", proxies);
+                        m.put("_proxiesInjected", true);
+                    }
+                }
+
+                LOGGER.info("render(): Received model with keys: {}", model.keySet());
+                LOGGER.info("Incoming request: {} {}", request.getMethod(), request.getRequestURI());
+
+                mustacheView.render(model, request, response);
+            }
+        };
+    }
+    
+    @Bean(name = "cas3SuccessViewDelegate")
+    public View cas3SuccessViewDelegate(
+        @Qualifier("casProtocolMustacheViewFactory") CasProtocolViewFactory factory,
+        ConfigurableApplicationContext context
+    ) {
+        return factory.create(context, "protocol/3.0/casServiceValidationSuccess");
+    }
+    
     //Fixes: Parameter 1 of method cesDebugServiceRegistry in de.triology.cas.services.CasCustomTemplateManagerConfiguration required a bean of type 'org.apereo.cas.services.util.RegisteredServiceJsonSerializer' that could not be found.
     @Bean
     @RefreshScope

--- a/app/src/main/java/de/triology/cas/services/CasCustomTemplateManagerConfiguration.java
+++ b/app/src/main/java/de/triology/cas/services/CasCustomTemplateManagerConfiguration.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.attribute.AttributeDefinitionStore;
-import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.services.ServiceRegistryProperties;
 import org.apereo.cas.services.util.RegisteredServiceJsonSerializer;

--- a/app/src/test/java/de/triology/cas/services/CasCustomTemplateManagerConfigurationTests.java
+++ b/app/src/test/java/de/triology/cas/services/CasCustomTemplateManagerConfigurationTests.java
@@ -3,7 +3,6 @@ package de.triology.cas.services;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.services.ServiceRegistryProperties;
 import org.apereo.cas.services.ServiceRegistry;
-import org.apereo.cas.services.ServiceRegistryExecutionPlanConfigurer;
 import org.apereo.cas.services.util.RegisteredServiceJsonSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/app/src/test/java/de/triology/cas/services/CesLegacyCompatibleTemplatesManagerTests.java
+++ b/app/src/test/java/de/triology/cas/services/CesLegacyCompatibleTemplatesManagerTests.java
@@ -7,7 +7,6 @@ import org.apereo.cas.util.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
### Changed
- Fix: Injects the missing `pgtUrl` attribute into the model in `cas3ServiceSuccessView` to properly render the `<cas:proxy>` element in the CAS 3.0 service ticket response.