### PR TITLE
Bugfix/266 OIDC session are not destroyed on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v7.0.10-2] - 2025-04-23
+## [v7.0.10-3] - 2025-05-09
+### Fixed
+- [#266] Fix destroying the oidc-session on logout
+   - The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
+   - Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour.
 
+## [v7.0.10-2] - 2025-04-23
 ### Changed
 - [#257] Set sensible resource requests and limits
 

--- a/app/src/main/java/de/triology/cas/oidc/config/CesOAuthConfiguration.java
+++ b/app/src/main/java/de/triology/cas/oidc/config/CesOAuthConfiguration.java
@@ -78,7 +78,8 @@ public class CesOAuthConfiguration {
 
     @Bean
     @RefreshScope
-    public LogoutExecutionPlanConfigurer oauthLogoutExecutionPlanConfigurer(SingleLogoutServiceMessageHandler oauthSingleLogoutServiceMessageHandler) {
+    public LogoutExecutionPlanConfigurer cesOAuthLogoutExecutionPlanConfigurer(
+            SingleLogoutServiceMessageHandler oauthSingleLogoutServiceMessageHandler) {
         return plan -> plan.registerSingleLogoutServiceMessageHandler(oauthSingleLogoutServiceMessageHandler);
     }
 

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -6,6 +6,11 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [Unreleased]
 
+## [v7.0.10-3] - 2025-05-09
+- Beenden der OIDC-Session beim Abmelden
+    - Wenn die Session beim Abmelden nicht beendet wurde, konnte das Benutzerprofil in der OIDC-Sitzung nicht aktualisiert werden, da eine "alte" Session mit dem "alten" Profil vorhanden war.
+    - Dies führte dazu, dass eventuelle Änderungen des Benutzers (z.B. Benutzername oder Gruppenzuordnungen) nicht aktualisiert wurden.
+  
 ## [v7.0.10-2] - 2025-04-23
 ### Changed
 - Die Verwendung von Speicher und CPU wurden für die Kubernetes-Multinode-Umgebung optimiert. 

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -6,6 +6,11 @@ Technical details on a release can be found in the corresponding [Changelog](htt
 
 ## [Unreleased]
 
+## [v7.0.10-3] - 2025-05-09
+- Fix destroying the oidc-session on logout
+  - When the session was not destroyed on logout the user-profile was cached and the user was not updated in the OIDC-session.
+  - This caused that possible changes of the user (like username or group assignments) were not updated
+
 ## [v7.0.10-2] - 2025-04-23
 ### Changed
 - Usage of memory and CPU was optimized for the Kubernetes Mutlinode environment. 

--- a/resources/etc/cas/config/cas.properties.tpl
+++ b/resources/etc/cas/config/cas.properties.tpl
@@ -299,6 +299,9 @@ cas.authn.oauth.code.numberOfUses=1
 # Access Token (Session) is valid for 1 day (= 86000 seconds)
 cas.authn.oauth.accessToken.timeToKillInSeconds=86000
 cas.authn.oauth.accessToken.maxTimeToLiveInSeconds=86000
+
+# https://apereo.github.io/cas/7.0.x/authentication/OIDC-Authentication-TokenExpirationPolicy.html#id-tokens
+cas.authn.oidc.id-token.include-id-token-claims=false
 ########################################################################################################################
 
 ########################################################################################################################


### PR DESCRIPTION
Fix destroying the oidc-session on logout.

The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour