### PR TITLE
Bugfix/266 OIDC session for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v7.0.10-3] - 2025-05-09
+### Fixed
+- [#266] Fix destroying the oidc-session on logout
+    - The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
+    - Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour.
+
 ## [v7.1.6-2] - 2025-05-08
 ### Changed
 - Fix: Injects the missing `pgtUrl` attribute into the model in `cas3ServiceSuccessView` to properly render the `<cas:proxy>` element in the CAS 3.0 service ticket response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#266] Fix destroying the oidc-session on logout
+    - The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
+    - Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour.
 
 ## [v7.0.10-3] - 2025-05-09
 ### Fixed

--- a/app/src/main/java/de/triology/cas/oidc/config/CesOAuthConfiguration.java
+++ b/app/src/main/java/de/triology/cas/oidc/config/CesOAuthConfiguration.java
@@ -78,7 +78,8 @@ public class CesOAuthConfiguration {
 
     @Bean
     @RefreshScope
-    public LogoutExecutionPlanConfigurer oauthLogoutExecutionPlanConfigurer(SingleLogoutServiceMessageHandler oauthSingleLogoutServiceMessageHandler) {
+    public LogoutExecutionPlanConfigurer cesOAuthLogoutExecutionPlanConfigurer(
+            SingleLogoutServiceMessageHandler oauthSingleLogoutServiceMessageHandler) {
         return plan -> plan.registerSingleLogoutServiceMessageHandler(oauthSingleLogoutServiceMessageHandler);
     }
 

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,9 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Beenden der OIDC-Session beim Abmelden
+    - Wenn die Session beim Abmelden nicht beendet wurde, konnte das Benutzerprofil in der OIDC-Sitzung nicht aktualisiert werden, da eine "alte" Session mit dem "alten" Profil vorhanden war.
+    - Dies führte dazu, dass eventuelle Änderungen des Benutzers (z.B. Benutzername oder Gruppenzuordnungen) nicht aktualisiert wurden.
 
 ## [v7.0.10-3] - 2025-05-09
 - Beenden der OIDC-Session beim Abmelden

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -6,6 +6,11 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [Unreleased]
 
+## [v7.0.10-3] - 2025-05-09
+- Beenden der OIDC-Session beim Abmelden
+    - Wenn die Session beim Abmelden nicht beendet wurde, konnte das Benutzerprofil in der OIDC-Sitzung nicht aktualisiert werden, da eine "alte" Session mit dem "alten" Profil vorhanden war.
+    - Dies führte dazu, dass eventuelle Änderungen des Benutzers (z.B. Benutzername oder Gruppenzuordnungen) nicht aktualisiert wurden.
+
 ## [v7.1.6-2] - 2025-05-08
 ### Behoben
 - Unterstützung für Proxy-Ticket-Authentifizierung wiederhergestellt – Dogus wie SCM können sich nun wieder über Smeagol mittels CAS authentifizieren.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,9 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Fix destroying the oidc-session on logout
+    - When the session was not destroyed on logout the user-profile was cached and the user was not updated in the OIDC-session.
+    - This caused that possible changes of the user (like username or group assignments) were not updated
 
 ## [v7.0.10-3] - 2025-05-09
 - Fix destroying the oidc-session on logout

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -6,6 +6,11 @@ Technical details on a release can be found in the corresponding [Changelog](htt
 
 ## [Unreleased]
 
+## [v7.0.10-3] - 2025-05-09
+- Fix destroying the oidc-session on logout
+    - When the session was not destroyed on logout the user-profile was cached and the user was not updated in the OIDC-session.
+    - This caused that possible changes of the user (like username or group assignments) were not updated
+
 ## [v7.1.6-2] - 2025-05-08
 ### Fixed
 - Restored support for proxy ticket authentication, allowing Dogus like SCM to authenticate via Smeagol using CAS.

--- a/resources/etc/cas/config/cas.properties.tpl
+++ b/resources/etc/cas/config/cas.properties.tpl
@@ -308,6 +308,9 @@ cas.authn.oauth.code.numberOfUses=1
 # Access Token (Session) is valid for 1 day (= 86000 seconds)
 cas.authn.oauth.accessToken.timeToKillInSeconds=86000
 cas.authn.oauth.accessToken.maxTimeToLiveInSeconds=86000
+
+# https://apereo.github.io/cas/7.0.x/authentication/OIDC-Authentication-TokenExpirationPolicy.html#id-tokens
+cas.authn.oidc.id-token.include-id-token-claims=false
 ########################################################################################################################
 
 ########################################################################################################################


### PR DESCRIPTION
Fix destroying the oidc-session on logout

The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour

closes #266