### PR TITLE
#269 Fix CAS 3 success view for Redmine missing formattedAttributes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [#266] Fix destroying the oidc-session on logout
-    - The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
-    - Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour.
-
-## [v7.0.10-3] - 2025-05-09
-### Fixed
+- [#269] Fix CAS 3 success view for Redmine missing formattedAttributes due to incomplete model
 - [#266] Fix destroying the oidc-session on logout
     - The "oauthLogoutExecutionPlanConfigurer"-bean was overwritten by the "CesOAuthConfiguration" which did not destroy the OIDC-session on logout.
     - Now there is "cesOAuthLogoutExecutionPlanConfigurer" which does not overwrite the default behaviour.

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,11 +5,7 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
-- Beenden der OIDC-Session beim Abmelden
-    - Wenn die Session beim Abmelden nicht beendet wurde, konnte das Benutzerprofil in der OIDC-Sitzung nicht aktualisiert werden, da eine "alte" Session mit dem "alten" Profil vorhanden war.
-    - Dies führte dazu, dass eventuelle Änderungen des Benutzers (z.B. Benutzername oder Gruppenzuordnungen) nicht aktualisiert wurden.
-
-## [v7.0.10-3] - 2025-05-09
+- Behebt das Problem bei der die CAS-3-SuccessView für Redmine unvollständig war und somit der Authtentifizierungsprozess fehl schlug.
 - Beenden der OIDC-Session beim Abmelden
     - Wenn die Session beim Abmelden nicht beendet wurde, konnte das Benutzerprofil in der OIDC-Sitzung nicht aktualisiert werden, da eine "alte" Session mit dem "alten" Profil vorhanden war.
     - Dies führte dazu, dass eventuelle Änderungen des Benutzers (z.B. Benutzername oder Gruppenzuordnungen) nicht aktualisiert wurden.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,11 +5,7 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
-- Fix destroying the oidc-session on logout
-    - When the session was not destroyed on logout the user-profile was cached and the user was not updated in the OIDC-session.
-    - This caused that possible changes of the user (like username or group assignments) were not updated
-
-## [v7.0.10-3] - 2025-05-09
+- Fix CAS 3 success view for Redmine missing formattedAttributes due to overwritten view and incomplete model
 - Fix destroying the oidc-session on logout
     - When the session was not destroyed on logout the user-profile was cached and the user was not updated in the OIDC-session.
     - This caused that possible changes of the user (like username or group assignments) were not updated


### PR DESCRIPTION
redmine auth flow with CAS failed because the expected user attributes were not present in the CAS 3.0 validation response. The custom View implementation replaced the default rendering logic but only injected principal and a manually added pgtUrl. Crucially, it omitted the formattedAttributes and other required user details, leading to failed attribute mapping in Redmine.

Resolution:
Rebuild the model to merge attributes from the protocolAttributeEncoder, the raw principal attributes, and explicitly mapped fields. Use CasProtocolAttributesRenderer to populate formattedAttributes, ensuring compatibility with Redmine's expectations.