### PR TITLE
#290 make "ldap" a non-optional dependency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#290] make "ldap" a non-optional dependency to avoid not having a ldap-service-account when dogus are installed in a "wrong" order
+  - If an external ldap should be used, this can be configured, but the internal "ldap"-dogu must be installed
 
 ## [v7.2.6-2] - 2025-09-10
 ### Changed

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,8 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+### Anpassungen
+-„ldap“ zu einer nicht optionalen Abhängigkeit gemacht, um zu vermeiden, dass kein LDAP‑Service‑Account vorhanden ist, wenn Dogus in einer „falschen“ Reihenfolge installiert werden.
 
 ## [v7.2.6-2] - 2025-09-10
 ### Behoben

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,8 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+### Changed
+- Made "ldap" a non-optional dependency to avoid not having a ldap-service-account when dogus are installed in a "wrong" order.
 
 ## [v7.2.6-2] - 2025-09-10
 ### Fixed

--- a/dogu.json
+++ b/dogu.json
@@ -21,9 +21,7 @@
     {
       "type": "dogu",
       "name": "postfix"
-    }
-  ],
-  "OptionalDependencies": [
+    },
     {
       "Type": "dogu",
       "Name": "ldap"


### PR DESCRIPTION
to avoid not having a ldap-service-account when dogus are installed in a "wrong" order