### PR TITLE
#297 Revert LDAP dependency to be an optional dependency again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#297] make "ldap" an optional dependency again and avoid a failing CAS upgrade 
+  - This change reverts #290 in version 7.2.6-3 from 2025-09-18 and makes external directory configurations a first-class
+    citizen again. 
+  - As in a CES VM the directory configuration is implemented in such an integral part that an additional LDAP dogu 
+    installation would lead to an unhealthy dogu on a regular basis. Unhealthy dogus are set to  
 
 ## [v7.2.7-2] - 2025-10-17
 ### Changed

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,10 +5,11 @@ Im Folgenden finden Sie die Release Notes für das CAS-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- Dieses Release behebt einen Upgrade-Fehler in solchen Umgebungen, die einen externen Verzeichnisdienst und nicht ein LDAP-Dogu verwenden. 
 
 ## [v7.2.7-2] - 2025-10-17
 ### Sicherheit
-- [#295] Behebung von CVE-2025-41232 - Schließt eine Sicherheitslücke in Spring Security, die unautorisierte Zugriffe ermöglichen konnte.
+- [#295] Behebung von CVE-2025-41232, das eine Sicherheitslücke in Spring Security schließt, die unautorisierte Zugriffe ermöglichen konnte.
 
 ## [v7.2.7-1] - 2025-10-06
 ### Anpassungen
@@ -16,7 +17,7 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [v7.2.6-3] - 2025-09-18
 ### Anpassungen
--„ldap“ zu einer nicht optionalen Abhängigkeit gemacht, um zu vermeiden, dass kein LDAP‑Service‑Account vorhanden ist, wenn Dogus in einer „falschen“ Reihenfolge installiert werden.
+-"ldap" wurde zu einer nicht-optionalen Abhängigkeit gemacht, um zu vermeiden, dass kein LDAP‑Service‑Account vorhanden ist, wenn Dogus in einer "falschen" Reihenfolge installiert werden.
 
 ## [v7.2.6-2] - 2025-09-10
 ### Behoben
@@ -67,7 +68,7 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [v7.1.6-1] - 2025-04-30
 ### Anpassungen
-- [#263] Upgrade CAS zu Version 7.1.6
+- Upgrade CAS zu einer neueren Version 7.1.6
 
 ## [v7.0.10-2] - 2025-04-23
 ### Anpassungen
@@ -75,7 +76,7 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [v7.0.10-1] - 2025-04-17
 ### Anpassungen
-- [#261] Upgrade CAS zu Version 7.0.10.1
+- Upgrade CAS zu einer neueren Version 7.0.10.1
 
 ## [v7.0.8-14] - 2025-04-16
 ### Sicherheit

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,7 @@ Below you will find the release notes for CAS-Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/de/docs/dogus/cas/CHANGELOG/).
 
 ## [Unreleased]
+- This release fixes an upgrade error in environments that use an external directory service rather than an LDAP dogu.
 
 ## [v7.2.7-2] - 2025-10-17
 ### Security

--- a/dogu.json
+++ b/dogu.json
@@ -21,7 +21,9 @@
     {
       "type": "dogu",
       "name": "postfix"
-    },
+    }
+  ],
+  "OptionalDependencies": [
     {
       "Type": "dogu",
       "Name": "ldap"


### PR DESCRIPTION
User directories like LDAP and Active Directory are first class citizens in the CES set-up since a long time. Thus, the configuration values are positioned in a way that they _not really_ allow for a double configuration: external directory AND internal LDAP dogu.

Instead, the values of the external directory must match to provide steady access to the directory. The LDAP dogu might then catch up on config values from the external directory, leading to dogu start up errors.

Besides being a technical problem this problem also arises another, both aesthetic and architectural: Administrators should not be forced to install two different solutions to the same problem to solve a problem that only arises from a problem within a unsufficient MN component implementation.

This commit reverts the ldap dogu dependency to an optional one and updates the necessary documents. This will provide admins with a way to an successful CAS upgrade again.