### PR TITLE
#345 Fix registration of CES password-management service (regression of #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#345] Fixed a regression of [#163] where password-reset mails were silently dropped for e-mail addresses without a real TLD (e.g. `admin@ces.local`), because the CES password-management service was no longer registered after the CAS 7 / Spring Boot 3 upgrade.
 
 ## [v7.2.7-19] - 2026-06-03
 ### Fixed

--- a/app/src/main/java/de/triology/cas/pm/LdapPasswordManagementConfiguration.java
+++ b/app/src/main/java/de/triology/cas/pm/LdapPasswordManagementConfiguration.java
@@ -7,9 +7,10 @@ import org.apereo.cas.util.LdapUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
 import lombok.val;
+import org.apereo.cas.config.CasLdapPasswordManagementAutoConfiguration;
 import org.ldaptive.ConnectionFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -20,14 +21,17 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This is {@link LdapPasswordManagementConfiguration}.
+ * <p>
+ * Registers {@link CesLdapPasswordManagementService} (which deactivates the e-mail address validation, see #163)
+ * as the active {@code passwordChangeService}.
  */
 @Configuration(value = "LdapPasswordManagementConfiguration", proxyBeanMethods = false)
-@ConditionalOnProperty(name = "cas.authn.pm.ldap[0].ldap-url")
+@AutoConfigureBefore(CasLdapPasswordManagementAutoConfiguration.class)
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class LdapPasswordManagementConfiguration {
 
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
-    @Bean
+    @Bean(name = {"passwordChangeService", "ldapPasswordChangeService"})
     public PasswordManagementService passwordChangeService(
             final CasConfigurationProperties casProperties,
             @Qualifier("passwordManagementCipherExecutor")

--- a/app/src/test/java/de/triology/cas/pm/LdapPasswordManagementConfigurationTests.java
+++ b/app/src/test/java/de/triology/cas/pm/LdapPasswordManagementConfigurationTests.java
@@ -5,10 +5,15 @@ import org.apereo.cas.configuration.model.core.authentication.AuthenticationProp
 import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
 import org.apereo.cas.pm.PasswordHistoryService;
 import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.config.CasLdapPasswordManagementAutoConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,5 +52,44 @@ class LdapPasswordManagementConfigurationTests {
 
         assertNotNull(service);
         assertTrue(service instanceof CesLdapPasswordManagementService);
+    }
+
+    /**
+     * Regression guard for #345 / #163: the config must not be gated by the indexed
+     * {@code @ConditionalOnProperty("cas.authn.pm.ldap[0].ldap-url")}, which stopped resolving
+     * after the CAS 6->7 / Spring Boot 2->3 upgrade and silently deactivated the CES override.
+     */
+    @Test
+    void shouldNotBeGatedByConditionalOnProperty() {
+        assertNull(LdapPasswordManagementConfiguration.class.getAnnotation(ConditionalOnProperty.class),
+                "@ConditionalOnProperty must not be present; the indexed [0] property broke registration of the CES override");
+    }
+
+    /**
+     * The CES config must be applied before Apereo's auto-configuration so the CES bean wins
+     * deterministically regardless of auto-configuration ordering.
+     */
+    @Test
+    void shouldBeAppliedBeforeApereoAutoConfiguration() {
+        var autoConfigureBefore = LdapPasswordManagementConfiguration.class.getAnnotation(AutoConfigureBefore.class);
+        assertNotNull(autoConfigureBefore, "@AutoConfigureBefore must be present");
+        assertTrue(List.of(autoConfigureBefore.value()).contains(CasLdapPasswordManagementAutoConfiguration.class),
+                "@AutoConfigureBefore must target CasLdapPasswordManagementAutoConfiguration");
+    }
+
+    /**
+     * The bean must be registered under both names so Apereo's
+     * {@code @ConditionalOnMissingBean(name = "ldapPasswordChangeService")} backs off and the CES
+     * service also becomes the active {@code passwordChangeService}.
+     */
+    @Test
+    void shouldRegisterBeanUnderBothNames() throws NoSuchMethodException {
+        Method method = LdapPasswordManagementConfiguration.class.getDeclaredMethod(
+                "passwordChangeService", CasConfigurationProperties.class, CipherExecutor.class, PasswordHistoryService.class);
+        var bean = method.getAnnotation(Bean.class);
+        assertNotNull(bean, "@Bean must be present on passwordChangeService");
+        var names = List.of(bean.name());
+        assertTrue(names.contains("passwordChangeService"), "bean must be named passwordChangeService");
+        assertTrue(names.contains("ldapPasswordChangeService"), "bean must also be named ldapPasswordChangeService");
     }
 }


### PR DESCRIPTION
After the CAS 6 => 7 / Spring Boot 2 => 3 upgrade, no mails were sent for CAS-driven flows but the UI reported *"Password Reset Instructions Sent Successfully"* — so the failure was invisible.

The drop was address-dependent and on the application layer:
- `admin@ces.local` => CAS logs `Email address [admin@ces.local] for [admin] is not valid` and sends nothing.
- `admin@example.com` => mail flows normally.

This is a regression of #163: `CesLdapPasswordManagementService` (which deliberately deactivates the e-mail-address validation for internal addresses like `admin@ces.local`) was no longer the active `passwordChangeService` at runtime.

The config class gated the CES override on `@ConditionalOnProperty(name = "cas.authn.pm.ldap[0].ldap-url")`. Indexed `[0]` property names are no longer resolved reliably by `@ConditionalOnProperty` since Spring Boot 3, so the condition silently stopped matching — the CES bean was never registered and the stock Apereo `passwordChangeService` (with active e-mail validation) took over.

Close #345 